### PR TITLE
Fix papers/templates/papers/search.html

### DIFF
--- a/papers/templates/papers/search.html
+++ b/papers/templates/papers/search.html
@@ -21,6 +21,7 @@
 {% endblock %}
 
 {% block jsScript %}
+{% if researcher %}
 $(function(){
        var config = {
          refreshURL: "{{ ajax_url }}",
@@ -44,6 +45,7 @@ $(function(){
        }
        init_paper_module(config)
     });
+{% endif %}
 {% endblock %}
 
 {% block details %}

--- a/papers/testpages.py
+++ b/papers/testpages.py
@@ -102,7 +102,7 @@ class PaperPagesTest(RenderingTest):
         self.checkPage('search', getargs={'name':self.r3.name_id})
 
     def test_search_department(self):
-        self.checkPage('search', getargs={'department':self.di})
+        self.checkPage('search', getargs={'department':self.di.pk})
 
     # ampersands not escaped in django bootstrap pagination, https://github.com/jmcclell/django-bootstrap-pagination/issues/41
 

--- a/papers/testpages.py
+++ b/papers/testpages.py
@@ -92,16 +92,19 @@ class PaperPagesTest(RenderingTest):
     def test_researcher_orcid(self):
         self.checkPage('researcher-by-orcid', kwargs={'orcid':self.r4.orcid})
 
-    # ampersands not escaped in django bootstrap pagination, https://github.com/jmcclell/django-bootstrap-pagination/issues/41
-    @unittest.expectedFailure
-    def test_search(self):
+    def test_search_no_parameters(self):
         self.checkPage('search')
-        self.checkPage('search', getargs={'researcher':self.r3.pk})
-        self.checkPage('search', getargs={'name':self.r3.name_id})
-        self.checkPage('search', getargs={'department':self.di})
-        # TODO more tests here
 
-#        url(r'^my-profile', views.myProfileView, name='my-profile'),
+    def test_search_researcher_pk(self):
+        self.checkPage('search', getargs={'researcher':self.r3.pk})
+
+    def test_search_name(self):
+        self.checkPage('search', getargs={'name':self.r3.name_id})
+
+    def test_search_department(self):
+        self.checkPage('search', getargs={'department':self.di})
+
+    # ampersands not escaped in django bootstrap pagination, https://github.com/jmcclell/django-bootstrap-pagination/issues/41
 
     def test_paper(self):
         for a in self.r3.authors_by_year:


### PR DESCRIPTION
@RaitoBezarius  I have added a guard to your JS block: it should only be run when we are looking at a researcher's profile (the search.html template is used for any view where we need to display publication lists, which includes many other cases, see `papers/views.py`).