### PR TITLE
Long titles should increase the size of the summary list

### DIFF
--- a/papers/static/style/style.css
+++ b/papers/static/style/style.css
@@ -204,6 +204,7 @@ h4
     flex: 7 1 70%;
     order: 1;
     align-self: stretch;
+    max-width: 750px;
 }
 
 #wrapper
@@ -356,6 +357,7 @@ li
 .pubText p
 {
     margin: 0px 0px 5px;
+    word-wrap: break-word;
 }
 
 .pubRef


### PR DESCRIPTION
In order to enforce the style, we put a `max-width: 750px` on the `#summaryLists` container, and to not let the long title overflow on the right container, we apply: `word-wrap: break-word;` on `.pubText p` (so that neither authors, neither title, neither references can overflow).

The result is the following:
![Screenshot of the changes](https://sc-cdn.scaleengine.net/i/476fedc1f19a94eed60a17a159a494bc.png)

(The long title is wrapped on the next line so you can still read it easily.)

Will close #268.