### PR TITLE
Fix search index preparation for departments

### DIFF
--- a/papers/search_indexes.py
+++ b/papers/search_indexes.py
@@ -43,7 +43,7 @@ class PaperIndex(indexes.SearchIndex, indexes.Indexable):
         return [r.id for r in obj.researchers.all()]
 
     def prepare_departments(self, obj):
-        return list(set([r.department.id for r in obj.researchers.all()]))
+        return list(set([r.department_id for r in obj.researchers.all()]))
 
     def prepare_publisher(self, obj):
         oairecord = obj.oairecords.filter(journal__isnull=False).first()


### PR DESCRIPTION
@Lysxia : I had a problem with search index population for departments: not all researchers have departments, so the original code failed when `r.department == None`. But anyway why don't we simply index all departments?