### PR TITLE
Separate download button from publisher

### DIFF
--- a/papers/static/style/style.css
+++ b/papers/static/style/style.css
@@ -371,6 +371,13 @@ li
     color: #272743;
 }
 
+.paperDownloadDomain
+{
+    color: #6e6e6e;
+    font-size: 0.9em;
+    margin-left: 5px;
+}
+
 .paperAuthors
 {
     font-size: 0.95em;

--- a/papers/templates/papers/publiListItem.html
+++ b/papers/templates/papers/publiListItem.html
@@ -1,6 +1,7 @@
 {% load author %}
 {% load i18n %}
 {% load cache %}
+{% load domain %}
 {% get_current_language as LANGUAGE_CODE %}
 {% cache 60000 publiListItem paper.pk LANGUAGE_CODE researcher_id %}
 <div class="pubLogo logoHelpPopover" data-content="{{ paper.status_helptext }}" rel="popover"
@@ -20,14 +21,8 @@
     <p class="paperTitle">
     <a href="{% url 'paper' paper.id paper.slug %}" class="paperItemTitle" data-pk="{{ paper.id }}" data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}">{% autoescape off %}{{ paper.title }}{% endautoescape %}</a>
     </p>
-    
-    <p class="pubRef">
-        {% if paper.pdf_url %}
-        <a href="{{ paper.pdf_url }}" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-save"></span> {% trans "Download" %}</a> |
-        {% else %}
-        <a href="{% url 'upload_paper' paper.pk %}" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-open"></span> {% trans "Upload" %}</a> | 
-        {% endif %}
 
+    <p class="pubRef">
         {% with paper.publications.first as publi %}
             {% if publi %}
                 {{ publi | publication }}.<br />
@@ -39,6 +34,14 @@
             {% endif %}
         {% endwith %}
     </p>
-    
+
+    <p class="paperDownload">
+        {% if paper.pdf_url %}
+        <a href="{{ paper.pdf_url }}" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-save"></span> {% trans "Download" %}</a>
+        <span class="paperDownloadDomain">{{ paper.pdf_url|domain }}</span>
+        {% else %}
+        <a href="{% url 'upload_paper' paper.pk %}" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-open"></span> {% trans "Upload" %}</a>
+        {% endif %}
+    </p>
 </div>
 {% endcache %}


### PR DESCRIPTION
Resolves #171

Now looks like this: 
![sc](https://cloud.githubusercontent.com/assets/2515201/16661206/298fd7c6-4472-11e6-8f48-edf00bcb6495.jpg)
