### PR TITLE
Run tests without Celery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ script:
   - python manage.py migrate --noinput
   - python manage.py loaddata dissemin/fixtures/test_dump.json
   - python manage.py rebuild_index --noinput
-  - ./celery.sh &
   - coverage run --source=dissemin,papers,backend,deposit,upload,statistics --omit=*/migrations/*,dissemin/settings/* manage.py test --testrunner dissemin.scripts.baretests.BareTestRunner -v 2 --failfast
 
 after_success:

--- a/backend/papersource.py
+++ b/backend/papersource.py
@@ -39,7 +39,7 @@ class PaperSource(object):
 
         :param max_results: maximum number of papers to retrieve for each researcher.
         """
-        self.max_results = None
+        self.max_results = max_results
 
     def fetch_papers(self, researcher):
         """

--- a/backend/pubtype_translations.py
+++ b/backend/pubtype_translations.py
@@ -70,6 +70,8 @@ OAI_PUBTYPE_TRANSLATIONS = {
         'typenorm:0106':'dataset',
         'typenorm:0107':'other', # sheet music
         'typenorm:9999':'other', # unknown
+        # RG
+        'inProceedings':'proceedings-article',
         }
 
 SET_TO_PUBTYPE = {

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -71,9 +71,6 @@ def init_profile_from_orcid(pk):
 
 @shared_task(name='fetch_everything_for_researcher')
 @run_only_once('researcher', keys=['pk'], timeout=15*60)
-def fetch_everything_for_reseracher_task(pk):
-    fetch_everything_for_researcher(pk)
-
 def fetch_everything_for_researcher(pk):
     sources = [
         ('orcid',OrcidPaperSource(max_results=1000)),

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -40,8 +40,7 @@ from papers.doi import to_doi
 from backend.crossref import *
 from backend.proxy import BASE_LOCAL_ENDPOINT
 from backend.orcid import *
-from backend.name_cache import name_lookup_cache
-from backend.extractors import * # to ensure that OaiSources are created
+import backend.extractors # to ensure that OaiSources are created
 from backend.utils import run_only_once
 
 logger = get_task_logger(__name__)
@@ -99,16 +98,6 @@ def fetch_everything_for_researcher(pk):
         r.update_stats()
         r.harvester = None
         update_researcher_task(r, None)
-        name_lookup_cache.prune()
-
-@shared_task(name='recluster_researcher')
-@run_only_once('researcher', keys=['pk'], timeout=15*60)
-def recluster_researcher(pk):
-    try:
-        r = Researcher.objects.get(pk=pk)
-    finally:
-        r.update_stats()
-        update_researcher_task(r, None)
 
 @shared_task(name='change_publisher_oa_status')
 def change_publisher_oa_status(pk, status):
@@ -129,20 +118,6 @@ def consolidate_paper(pk):
                 break
     except Paper.DoesNotExist:
         print "consolidate_paper: unknown paper %d" % pk
-
-@shared_task(name='get_bare_paper_by_doi')
-def get_bare_paper_by_doi(doi):
-    cr_api = CrossRefAPI()
-    p = cr_api.create_paper_by_doi(doi)
-    return p
-
-@shared_task(name='get_paper_by_doi')
-def get_paper_by_doi(doi):
-    cr_api = CrossRefAPI()
-    p = cr_api.create_paper_by_doi(doi)
-    if p is not None:
-        p = Paper.from_bare(p)
-    return p
 
 @shared_task(name='update_all_stats')
 @run_only_once('refresh_stats', timeout=3*60)

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -25,6 +25,7 @@ import requests.exceptions
 from time import sleep
 from titlecase import titlecase
 from dissemin.settings import redis_client
+from memoize import memoize
 
 from papers.errors import MetadataSourceException
 
@@ -88,5 +89,9 @@ def urlopen_retry(url, **kwargs):# data, timeout, retries, delay, backoff):
             retries=retries-1,
             delay=delay*backoff,
             backoff=backoff)
+
+@memoize(timeout=86400) # 1 day
+def cached_urlopen_retry(*args, **kwargs):
+    return urlopen_retry(*args, **kwargs)
 
 

--- a/dissemin/settings/travis.py
+++ b/dissemin/settings/travis.py
@@ -48,6 +48,8 @@ SOCIALACCOUNT_PROVIDERS = \
        }
    }
 
+# Mock Celery (run tasks directly in the main process)
+CELERY_ALWAYS_EAGER = True
 
 # Debug Email Backend
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/dissemin/testsettings.py
+++ b/dissemin/testsettings.py
@@ -1,3 +1,4 @@
 from dissemin.settings import *
 
 DEBUG_TOOLBAR_CONFIG = {'SHOW_TOOLBAR_CALLBACK': lambda r: False}
+CELERY_ALWAYS_EAGER = True

--- a/papers/ajax.py
+++ b/papers/ajax.py
@@ -34,7 +34,6 @@ from django.utils.translation import ugettext as __
 import json, requests
 
 from django.views.decorators.csrf import csrf_exempt
-from celery.execute import send_task
 
 from dissemin.settings import URL_DEPOSIT_DOWNLOAD_TIMEOUT, DEPOSIT_MAX_FILE_SIZE, MEDIA_ROOT
 
@@ -267,7 +266,8 @@ def changePublisherStatus(request):
         publisher = Publisher.objects.get(pk=pk)
         status = request.POST.get('status')
         if status in allowedStatuses and status != publisher.oa_status:
-            send_task('change_publisher_oa_status', [], {'pk':pk,'status':status})
+            from backend.tasks import change_publisher_oa_status
+            change_publisher_oa_status.delay(pk=pk,status=status)
             return HttpResponse('OK', content_type='text/plain')
         else:
             raise ObjectDoesNotExist

--- a/papers/models.py
+++ b/papers/models.py
@@ -64,7 +64,6 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from caching.base import CachingManager, CachingMixin
 from solo.models import SingletonModel
-from celery.execute import send_task
 from celery.result import AsyncResult
 
 from papers.baremodels import *
@@ -73,6 +72,7 @@ from papers.utils import remove_diacritics, sanitize_html, validate_orcid, affil
 from papers.orcid import OrcidProfile
 from papers.doi import to_doi
 from papers.errors import MetadataSourceException
+
 
 from statistics.models import AccessStatistics, STATUS_CHOICES_HELPTEXT, combined_status_for_instance
 from publishers.models import Publisher, Journal, OA_STATUS_CHOICES, OA_STATUS_PREFERENCE, DummyPublisher
@@ -347,7 +347,8 @@ class Researcher(models.Model):
         self.stats.update(self.papers)
 
     def fetch_everything(self):
-        self.harvester = send_task('fetch_everything_for_researcher', [], {'pk':self.id}).id
+        from backend.tasks import fetch_everything_for_researcher_task
+        self.harvester = fetch_everything_for_researcher_task.delay(pk=self.id).id
         self.current_task = 'init'
         self.save(update_fields=['harvester','current_task'])
 
@@ -355,13 +356,9 @@ class Researcher(models.Model):
         if self.last_harvest is None or timezone.now() - self.last_harvest > PROFILE_REFRESH_ON_LOGIN:
             self.fetch_everything()
 
-    def recluster_batch(self):
-        self.harvester = send_task('recluster_researcher', [], {'pk':self.id}).id
-        self.current_task = 'clustering'
-        self.save(update_fields=['harvester','current_task'])
-
     def init_from_orcid(self):
-        self.harvester = send_task('init_profile_from_orcid', [], {'pk':self.id}).id
+        from backend.tasks import init_profile_from_orcid
+        self.harvester = init_profile_from_orcid(pk=self.id).id
         self.current_task = 'init'
         self.save(update_fields=['harvester', 'current_task'])
 
@@ -804,7 +801,8 @@ class Paper(models.Model, BarePaper):
         possibly by fetching it from Zotero via doi-cache.
         """
         if self.task is None:
-            task = send_task('consolidate_paper', [], {'pk':self.id})
+            from backend.tasks import consolidate_paper
+            task = consolidate_paper.delay(pk=self.id)
             self.task = task.id
             self.save(update_fields=['task'])
         else:
@@ -813,20 +811,13 @@ class Paper(models.Model, BarePaper):
             task.get()
 
     @classmethod
-    def create_by_doi(self, doi, wait=True, bare=False):
+    def create_by_doi(self, doi, bare=False):
         """
-        Creates a paper given a DOI (sends a task to the backend).
+        Creates a paper given a DOI
         """
-        if not bare:
-            task = send_task('get_paper_by_doi', [], {'doi':doi})
-        else:
-            import backend.crossref as crossref
-            import backend.oai as oai
-            cr_api = crossref.CrossRefAPI()
-            return cr_api.create_paper_by_doi(doi)
-
-        if wait:
-            return task.get()
+        import backend.crossref as crossref
+        cr_api = crossref.CrossRefAPI()
+        return cr_api.create_paper_by_doi(doi)
 
     def successful_deposits(self):
         return self.depositrecord_set.filter(pdf_url__isnull=False)

--- a/papers/testajax.py
+++ b/papers/testajax.py
@@ -154,7 +154,6 @@ class PublisherAjaxTest(JsonRenderingTest):
                 postargs={'pk':self.publisher.pk,
                           'status':'OA'})
         self.assertEqual(p.status_code, 200)
-        sleep(3)
         papers = [Paper.objects.get(pk=p.pk) for p in self.papers]
         self.assertTrue(all([p.oa_status == 'OA' for p in papers]))
 

--- a/papers/urls.py
+++ b/papers/urls.py
@@ -45,7 +45,6 @@ urlpatterns = [
         # Tasks, AJAX
         url(r'^ajax/', include('papers.ajax')),
         url(r'^researcher/(?P<pk>\d+)/update/$', views.refetchResearcher, name='refetch-researcher'),
-        url(r'^researcher/(?P<pk>\d+)/recluster/$', views.reclusterResearcher, name='recluster-researcher'),
         # API
         url(r'^api/', include('papers.api')),
         # Annotations (to be deleted)


### PR DESCRIPTION
Using `CELERY_ALWAYS_EAGER`, we can fake tasks (they are executed directly in the process that spawns them. For this, we needed to get rid of `send_task` which is not affected by this feature. This was the occasion to remove some unused tasks.