### PR TITLE
Minimal affiliation field with autocompletion for HAL

### DIFF
--- a/autocomplete/__init__.py
+++ b/autocomplete/__init__.py
@@ -1,0 +1,1 @@
+from . import views

--- a/autocomplete/forms.py
+++ b/autocomplete/forms.py
@@ -1,0 +1,3 @@
+from django import forms
+
+# place form definition here

--- a/autocomplete/models.py
+++ b/autocomplete/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/autocomplete/urls.py
+++ b/autocomplete/urls.py
@@ -1,0 +1,11 @@
+# -*- encoding: utf-8 -*-
+
+from __future__ import unicode_literals
+from autocomplete import views
+from django.conf.urls import url
+
+urlpatterns = [
+    url(r'^autocomplete_affiliations/$',
+        views.AffiliationAutocomplete.as_view(),
+        name='autocomplete_affiliations')
+]

--- a/autocomplete/views.py
+++ b/autocomplete/views.py
@@ -1,0 +1,92 @@
+from dal.views import ViewMixin
+from dal_select2.views import Select2ViewMixin
+from django.views.generic import View
+from django.core.exceptions import SuspiciousOperation
+import requests
+import json
+
+
+HAL_API_AUTHOR_STRUCTURE = (
+    'https://api.archives-ouvertes.fr/search/authorstructure/'
+)
+
+
+class AffiliationAutocomplete(View, ViewMixin, Select2ViewMixin):
+    """
+        Fetch the affiliations from HAL API
+        - FIXME: handle pagination if there is.
+        - FIXME: what happens when no results?
+        - FIXME: handle error for requests
+    """
+    # Never display option to create a new field.
+    create_field = False
+
+    def get_result_value(self, result):
+        return result[1]
+
+    def get_result_label(self, result):
+        return result[0]
+
+    def has_more(self, context):
+        return context.get('has_more', False)
+
+    def fetch_affiliations(self, author):
+        r = requests.get(HAL_API_AUTHOR_STRUCTURE, params={
+            'firstName_t': author['first_name'],
+            'lastName_t': author['last_name'],
+            'wt': 'json'
+        })
+        r.raise_for_status()
+        affiliations = r.json()['response']['result']
+
+        if not affiliations:
+            return {
+                'object_list': [],
+                'has_more': False
+            }
+
+        affiliations = affiliations['org']
+
+        return {
+            'object_list': [(
+                aff['orgName'][0],
+                aff['idno']
+            ) for aff in affiliations
+                if 'idno' in aff],
+            'has_more': False
+        }
+
+    def get(self, request, *args, **kwargs):
+        context = {}
+
+        # Author data
+        first_name = request.GET.get('first_name', None)
+        last_name = request.GET.get('last_name', None)
+
+        try:
+            forward = request.GET.get('forward', None)
+            if forward is not None:
+                forward = json.loads(forward)
+        except:
+            raise SuspiciousOperation('forward is not proper JSON object')
+
+        if not first_name and not last_name and forward:
+            first_name = forward.get('first_name', None)
+            last_name = forward.get('last_name', None)
+
+        if not first_name:
+            raise SuspiciousOperation(
+                'first_name is missing'
+            )
+
+        if not last_name:
+            raise SuspiciousOperation(
+                'last_name is missing'
+            )
+
+        context = self.fetch_affiliations({
+            'first_name': first_name,
+            'last_name': last_name
+        })
+
+        return self.render_to_response(context)

--- a/autocomplete/widgets.py
+++ b/autocomplete/widgets.py
@@ -1,0 +1,6 @@
+from dal.widgets import Select
+from dal_select2.widgets import Select2WidgetMixin
+
+
+class Select2(Select2WidgetMixin, Select):
+    """Select2 widget for regular choices."""

--- a/deposit/forms.py
+++ b/deposit/forms.py
@@ -85,9 +85,9 @@ class BaseMetadataForm(forms.Form):
     # Dummy field to store the paper id (required for dynamic fetching of the
     # abstract)
     paper_id = forms.IntegerField(
-            required=False,
-            widget=forms.HiddenInput
-            )
+        required=False,
+        widget=forms.HiddenInput
+    )
     abstract = forms.CharField(
             label=__('Abstract'),
             required=True,

--- a/deposit/hal/forms.py
+++ b/deposit/hal/forms.py
@@ -70,6 +70,7 @@ class HALForm(BaseMetadataForm):
             choices=HAL_TOPIC_CHOICES)
 
     affiliation = forms.CharField(
+        required=False,
         label=__('Affiliation'),
         widget=Select2(forward=['first_name', 'last_name'], url='autocomplete_affiliations')
     )

--- a/deposit/hal/forms.py
+++ b/deposit/hal/forms.py
@@ -22,20 +22,54 @@ from __future__ import unicode_literals
 
 from crispy_forms.helper import FormHelper
 from deposit.forms import BaseMetadataForm
-from deposit.hal.metadata import HAL_TOPIC_CHOICES
 from django import forms
 from django.utils.translation import ugettext as __
+
+from autocomplete.widgets import Select2
+
+HAL_TOPIC_CHOICES = [
+    ('CHIM', __('Chemistry')),
+    ('INFO', __('Computer science')),
+    ('MATH', __('Mathematics')),
+    ('PHYS', __('Physics')),
+    ('NLIN', __('Non-linear science')),
+    ('SCCO', __('Cognitive science')),
+    ('SDE', __('Environment sciences')),
+    ('SDU', __('Planet and Universe')),
+    ('SHS', __('Humanities and Social Science')),
+    ('SDV', __('Life sciences')),
+    ('SPI', __('Engineering sciences')),
+    ('STAT', __('Statistics')),
+    ('QFIN', __('Economy and quantitative finance')),
+    ('OTHER', __('Other')),
+  ]
 
 
 class HALForm(BaseMetadataForm):
 
-    def __init__(self, *args, **kwargs):
-        super(HALForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-lg-2'
-        self.helper.field_class = 'col-lg-8'
+#    def __init__(self, *args, **kwargs):
+#        super(HALForm, self).__init__(*args, **kwargs)
+#        self.helper = FormHelper(self)
+#        self.helper.form_class = 'form-horizontal'
+#        self.helper.label_class = 'col-lg-2'
+#        self.helper.field_class = 'col-lg-8'
+
+    # Dummy field to store the user name
+    # (required for affiliation autocompletion)
+    first_name = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput
+    )
+    last_name = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput
+    )
 
     topic = forms.ChoiceField(
             label=__('Scientific field'),
             choices=HAL_TOPIC_CHOICES)
+
+    affiliation = forms.CharField(
+        label=__('Affiliation'),
+        widget=Select2(forward=['first_name', 'last_name'], url='autocomplete_affiliations')
+    )

--- a/deposit/hal/metadata.py
+++ b/deposit/hal/metadata.py
@@ -230,4 +230,9 @@ class AOFRFormatter(MetadataFormatter):
 def generate(theId):
     formatter = AOFRFormatter()
     paper = Paper.objects.get(pk=theId)
-    return formatter.toString(paper, 'article.pdf', True)
+    form = HALForm({
+        'topic': 'CHIM',
+        'abstract': 'Here is some info'
+    })
+    form.is_valid()
+    return formatter.toString(paper, 'article.pdf', form, True), paper

--- a/deposit/hal/metadata.py
+++ b/deposit/hal/metadata.py
@@ -142,7 +142,7 @@ class AOFRFormatter(MetadataFormatter):
 
         abstract = addChild(profileDesc, 'abstract')
         abstract.attrib[XMLLANG_ATTRIB] = 'en'
-        abstract.text = 'No abstract.'
+        abstract.text = 'No abstract.' if not form.cleaned_data['abstract'] else form.cleaned_data['abstract']
         for record in paper.sorted_oai_records:
             if record.description:
                 abstract.text = record.description

--- a/deposit/hal/metadata.py
+++ b/deposit/hal/metadata.py
@@ -27,26 +27,9 @@ from __future__ import unicode_literals
 
 from deposit.sword.metadata import addChild
 from deposit.sword.metadata import MetadataFormatter
-from django.utils.translation import ugettext_lazy as _
 from lxml import etree
 from papers.models import Paper
-
-HAL_TOPIC_CHOICES = [
-    ('CHIM', _('Chemistry')),
-    ('INFO', _('Computer science')),
-    ('MATH', _('Mathematics')),
-    ('PHYS', _('Physics')),
-    ('NLIN', _('Non-linear science')),
-    ('SCCO', _('Cognitive science')),
-    ('SDE', _('Environment sciences')),
-    ('SDU', _('Planet and Universe')),
-    ('SHS', _('Humanities and Social Science')),
-    ('SDV', _('Life sciences')),
-    ('SPI', _('Engineering sciences')),
-    ('STAT', _('Statistics')),
-    ('QFIN', _('Economy and quantitative finance')),
-    ('OTHER', _('Other')),
-  ]
+from deposit.hal.forms import HALForm
 
 ENS_HAL_ID = 59704
 
@@ -96,7 +79,7 @@ class AOFRFormatter(MetadataFormatter):
         self.renderTitleAuthors(titleStmt, paper)
 
         # editionStmt
-        if filename != None:
+        if filename is not None:
             editionStmt = addChild(biblFull, 'editionStmt')
             edition = addChild(editionStmt, 'edition')
             date = addChild(edition, 'date')

--- a/deposit/hal/protocol.py
+++ b/deposit/hal/protocol.py
@@ -151,6 +151,12 @@ class HALProtocol(RepositoryProtocol):
             parser = etree.XMLParser(encoding='utf-8')
             receipt = etree.parse(BytesIO(xml_response), parser)
             receipt = receipt.getroot()
+            if receipt.tag == '{http://purl.org/net/sword/error/}error':
+                self.log('Error while depositing the content.')
+                self.log('Here is the XML response: {}'.format(xml_response))
+                self.log('Here is the metadata: {}'.format(metadata))
+                raise DepositError(__('HAL rejected the submission'))
+
             deposition_id = receipt.find('{http://www.w3.org/2005/Atom}id').text
             # TODO store the password for the paper:
             # can be used later by the user to modify the upload
@@ -190,8 +196,8 @@ class HALProtocol(RepositoryProtocol):
             self.log("Caught exception:")
             self.log(str(type(e))+': '+str(e)+'')
             self.log(traceback.format_exc())
-            raise DepositError(
-                'Connection to HAL failed. Please try again later.')
+            raise DepositError(__(
+                'Connection to HAL failed. Please try again later.'))
 
         return deposit_result
 

--- a/deposit/hal/protocol.py
+++ b/deposit/hal/protocol.py
@@ -74,6 +74,9 @@ class HALProtocol(RepositoryProtocol):
         data = {}
         data['paper_id'] = self.paper.id
 
+        data['first_name'] = self.user.first_name
+        data['last_name'] = self.user.last_name
+
         # Abstract
         if self.paper.abstract:
             data['abstract'] = kill_html(self.paper.abstract)

--- a/deposit/templates/deposit/start.html
+++ b/deposit/templates/deposit/start.html
@@ -21,11 +21,14 @@
     <script src="{% static "libs/jquery.iframe-transport.js" %}"></script>
     <script src="{% static "libs/jquery.fileupload.js" %}"></script>
     <script src="{% static "libs/upload.js" %}"></script>
+
     <link rel="stylesheet" href="{% static "css/upload.css" %}" />
     <link rel="stylesheet" href="{% static "css/deposit.css" %}" />
 {% endblock %}
 
 {% block jsScript %}
+yl = {};
+yl.jQuery = $;
 $(function() {
     $('#waitingArea').hide();
     $('#uploadFileId').val('');
@@ -297,4 +300,8 @@ $(function() {
 {% block details %}
 {% include "papers/paperDetails.html" with paper=paper %}
 
+{% endblock %}
+
+{% block footer %}
+        {{ selected_protocol.get_form.media }}
 {% endblock %}

--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -121,6 +121,8 @@ PROFILE_REFRESH_ON_LOGIN = timedelta(days=1)
 # You should not have to change anything in this section.
 
 INSTALLED_APPS = (
+    'dal',
+    'dal_select2',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -142,6 +142,7 @@ INSTALLED_APPS = (
     'deposit.zenodo',
     'deposit.hal',
     'deposit.sword',
+    'autocomplete',
     'notification',
     'bootstrap_pagination',
     'django_js_reverse',

--- a/dissemin/urls.py
+++ b/dissemin/urls.py
@@ -102,6 +102,7 @@ urlpatterns = [
     url(r'^', include('publishers.urls')),
     url(r'^', include('deposit.urls')),
     url(r'^', include('notification.urls')),
+    url(r'^', include('autocomplete.urls')),
     url(r'^jsreverse/$', 'django_js_reverse.views.urls_js', name='js_reverse'),
     # Social auth
     url(r'^accounts/login/$', LoginView.as_view(), name='account_login'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ django-solo
 django-widget-tweaks
 django-memoize
 django-bulk-update
+django-autocomplete-light
 djangorestframework
 elasticsearch
 html5lib==0.999999999

--- a/templates/dissemin/skeleton.html
+++ b/templates/dissemin/skeleton.html
@@ -143,4 +143,6 @@
 
     <img style="position:absolute; top:0; left:0; border:0; opacity: 0.8; pointer-events: none;" src="{% static "img/beta-ribbon.png" %}" alt="Beta version" />
 </body>
+{% block footer %}
+{% endblock %}
 </html>


### PR DESCRIPTION
(do not merge)

It uses the current user who is depositing to check the affiliations.
If no affiliation is found, we report it appropriately.

We have to use `idno` to get the ID of each affiliation which is given.

Todo : 
- [ ] insert the affiliation in the markup for the deposition
- [ ] make the field cuter
- [ ] i18n the whole thing
- [ ] clean out the code

Refer to #248 for more information.