### PR TITLE
Fix Dissemin (and @wetneb's browser)

### DIFF
--- a/papers/static/style/style.css
+++ b/papers/static/style/style.css
@@ -338,7 +338,7 @@ li
 	width:100%;
 }
 
-.pubText, .criterionItem
+.publicationText, .criterionItem
 {
     margin-top: 15px;
     margin-bottom: 15px;
@@ -347,14 +347,14 @@ li
     padding-bottom: 5px;
 }
 
-.pubText
+.publicationText
 {
     margin-left: 60px;
     border-left: 3px solid #8ECC50;
     min-height: 55px;
 }
 
-.pubText p
+.publicationText p
 {
     margin: 0px 0px 5px;
     word-wrap: break-word;

--- a/papers/templates/papers/publiListItem.html
+++ b/papers/templates/papers/publiListItem.html
@@ -9,7 +9,7 @@
     <img src="/static/img/logos/{{ paper.combined_status }}.png" width="52" height="70" />
 </div>
 
-<div class="pubText">
+<div class="publicationText">
     <p class="paperAuthors">
         {% include "papers/authorList.html" with author_list=paper.displayed_authors %}
         {% if paper.has_many_authors %}


### PR DESCRIPTION
Class `.pubText` is blocked by Easyliste-FR starting from recently.
Dissemin was missing a lot of text blocks when uBlock/AdBlock is
enabled.