### PR TITLE
Support for Sentry

### DIFF
--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -147,6 +147,7 @@ INSTALLED_APPS = (
     'django_countries',
     'leaflet',
     'djgeojson',
+    'raven.contrib.django.raven_compat'
 )
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,6 @@ unicode_tex
 unidecode
 urllib3
 wand
+raven
 python-dateutil # for haystack, as explained here:
 #http://django-haystack.readthedocs.io/en/v2.4.1/management_commands.html


### PR DESCRIPTION
Add Sentry's error reporting.

I'll add the necessary keys (on dissem.in and sandbox maybe) by myself once it's merged.

(if no key is specified, it won't interfere / throw an error / fail / crash / burn your house, no worries.)

[Here the reference for Django](https://docs.sentry.io/clients/python/integrations/django/)
Theorically, keys should be added in `secrets.py`.

I should document this… :smile: 

Also, once I get approval from sentry.io for open source Sentry, I'll enable GitHub auth through the Dissemin org, so that everyone in the org can access to the Sentry Dissemin's org.