### PR TITLE
[enh] replace dx.doi.org by doi.org

### DIFF
--- a/backend/crossref.py
+++ b/backend/crossref.py
@@ -58,7 +58,7 @@ from backend.pubtype_translations import CROSSREF_PUBTYPE_ALIASES
 # 1. Background on DOIs
 #
 # DOIs are managed by the DOI International Foundation. They provide
-# a persistent identifier for objects. dx.doi.org redirects to the current
+# a persistent identifier for objects. doi.org redirects to the current
 # URL for a given DOI (this URL can be updated by the provider).
 #
 # DOIs can be emitted by many different providers: among others, CrossRef,
@@ -274,7 +274,7 @@ def _create_publication(paper, metadata):
 def fetch_metadata_by_DOI(doi):
     """
     Fetch the metadata for a single DOI.
-    This is supported by the standard proxy, dx.doi.org,
+    This is supported by the standard proxy, doi.org,
     as well as more advanced proxies such as doi_cache
     """
     if doi is None:

--- a/backend/testcrossref.py
+++ b/backend/testcrossref.py
@@ -113,7 +113,7 @@ class CrossRefUnitTest(unittest.TestCase):
                           'DOI': '10.5380/dp.v1i1.1922',
                           'subtitle': [],
                           'author': [{'given': 'Frederic', 'family': 'Worms'}],
-                          'URL': 'http://doi.org/10.5380/dp.v1i1.1922',
+                          'URL': 'https://doi.org/10.5380/dp.v1i1.1922',
                           'issued': {'date-parts': [[2005, 3, 18]]},
                           'reference-count': 0,
                           'title': 'A concep\xe7\xe3o bergsoniana do tempo',

--- a/backend/testcrossref.py
+++ b/backend/testcrossref.py
@@ -113,7 +113,7 @@ class CrossRefUnitTest(unittest.TestCase):
                           'DOI': '10.5380/dp.v1i1.1922',
                           'subtitle': [],
                           'author': [{'given': 'Frederic', 'family': 'Worms'}],
-                          'URL': 'http://dx.doi.org/10.5380/dp.v1i1.1922',
+                          'URL': 'http://doi.org/10.5380/dp.v1i1.1922',
                           'issued': {'date-parts': [[2005, 3, 18]]},
                           'reference-count': 0,
                           'title': 'A concep\xe7\xe3o bergsoniana do tempo',

--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -74,7 +74,7 @@ BASE_DIR = os.path.dirname(os.path.join(
 # curl -LH "Accept: application/citeproc+json" http://DOI_PROXY_DOMAIN/10.1080/15568318.2012.660115
 # (returns the citation as Citeproc+JSON)
 #
-# This acts as a caching proxy for dx.doi.org
+# This acts as a caching proxy for doi.org
 DOI_PROXY_DOMAIN = 'doi-cache.dissem.in'
 #
 # In addition, if the endpoint supports it, batch requests can be performed:
@@ -86,7 +86,7 @@ DOI_PROXY_SUPPORTS_BATCH = True
 # Uncomment these settings if you rather want
 # to fetch metadata directly from CrossRef (slower as not cached,
 # and more requests as there is no batch support).
-#DOI_PROXY_DOMAIN =  'dx.doi.org'
+#DOI_PROXY_DOMAIN =  'doi.org'
 #DOI_PROXY_SUPPORTS_BATCH = False
 
 

--- a/papers/baremodels.py
+++ b/papers/baremodels.py
@@ -882,7 +882,7 @@ class BareOaiRecord(BareObject):
             return 'OA'
         elif self.publisher:
             if self.publisher.oa_status == 'OA' and self.doi:
-                self.pdf_url = 'http://dx.doi.org/'+self.doi
+                self.pdf_url = 'http://doi.org/'+self.doi
             return self.publisher.oa_status
         else:
             return 'UNK'

--- a/papers/baremodels.py
+++ b/papers/baremodels.py
@@ -882,7 +882,7 @@ class BareOaiRecord(BareObject):
             return 'OA'
         elif self.publisher:
             if self.publisher.oa_status == 'OA' and self.doi:
-                self.pdf_url = 'http://doi.org/'+self.doi
+                self.pdf_url = 'https://doi.org/'+self.doi
             return self.publisher.oa_status
         else:
             return 'UNK'

--- a/papers/doi.py
+++ b/papers/doi.py
@@ -35,7 +35,7 @@ openaire_doi_re = re.compile(
 
 def to_doi(candidate):
     """
-    >>> to_doi('http://doi.org/10.1145/1721837.1721839')
+    >>> to_doi('https://doi.org/10.1145/1721837.1721839')
     u'10.1145/1721837.1721839'
     >>> to_doi('https://doi.org/10.1145/1721837.1721839')
     u'10.1145/1721837.1721839'

--- a/papers/doi.py
+++ b/papers/doi.py
@@ -35,7 +35,7 @@ openaire_doi_re = re.compile(
 
 def to_doi(candidate):
     """
-    >>> to_doi('http://dx.doi.org/10.1145/1721837.1721839')
+    >>> to_doi('http://doi.org/10.1145/1721837.1721839')
     u'10.1145/1721837.1721839'
     >>> to_doi('https://doi.org/10.1145/1721837.1721839')
     u'10.1145/1721837.1721839'

--- a/papers/templatetags/doi.py
+++ b/papers/templatetags/doi.py
@@ -10,4 +10,4 @@ register = template.Library()
 
 @register.filter(is_safe=True)
 def doi_to_url(doi):
-    return mark_safe('http://doi.org/'+escape(doi.doi))
+    return mark_safe('https://doi.org/'+escape(doi.doi))

--- a/papers/templatetags/doi.py
+++ b/papers/templatetags/doi.py
@@ -10,4 +10,4 @@ register = template.Library()
 
 @register.filter(is_safe=True)
 def doi_to_url(doi):
-    return mark_safe('http://dx.doi.org/'+escape(doi.doi))
+    return mark_safe('http://doi.org/'+escape(doi.doi))

--- a/papers/testnames.py
+++ b/papers/testnames.py
@@ -513,7 +513,7 @@ class UnifyNameListsTest(unittest.TestCase):
 
     def test_inverted(self):
         # in the wild:
-        # http://dx.doi.org/10.1371/journal.pone.0156198
+        # http://doi.org/10.1371/journal.pone.0156198
         # http://hdl.handle.net/11573/870611
         self.assertEqual(len(filter(lambda x: x[0] != None,
                                     unify_name_lists(

--- a/papers/testnames.py
+++ b/papers/testnames.py
@@ -513,7 +513,7 @@ class UnifyNameListsTest(unittest.TestCase):
 
     def test_inverted(self):
         # in the wild:
-        # http://doi.org/10.1371/journal.pone.0156198
+        # https://doi.org/10.1371/journal.pone.0156198
         # http://hdl.handle.net/11573/870611
         self.assertEqual(len(filter(lambda x: x[0] != None,
                                     unify_name_lists(

--- a/papers/tests.py
+++ b/papers/tests.py
@@ -198,7 +198,7 @@ class PaperTest(django.test.TestCase):
         p = Paper.from_bare(p)
         # so the pdf_url of the publication should be set
         self.assertEqual(p.publications[0].pdf_url.lower(
-            ), 'http://dx.doi.org/10.1007/BF02702259'.lower())
+            ), 'http://doi.org/10.1007/BF02702259'.lower())
 
     def test_create_no_authors(self):
         p = Paper.create_by_doi('10.1021/cen-v043n050.p033')

--- a/papers/tests.py
+++ b/papers/tests.py
@@ -198,7 +198,7 @@ class PaperTest(django.test.TestCase):
         p = Paper.from_bare(p)
         # so the pdf_url of the publication should be set
         self.assertEqual(p.publications[0].pdf_url.lower(
-            ), 'http://doi.org/10.1007/BF02702259'.lower())
+            ), 'https://doi.org/10.1007/BF02702259'.lower())
 
     def test_create_no_authors(self):
         p = Paper.create_by_doi('10.1021/cen-v043n050.p033')


### PR DESCRIPTION
Doi.org asks to systematically substitute doi.org to dx.doi.org

Source: https://hyp.is/M9Lj0GjaEeeB4idO26hqow/www.doi.org/factsheets/DOIProxy.html