### PR TITLE
Forbid "OTHER" topic in HAL form

### DIFF
--- a/deposit/hal/metadata.py
+++ b/deposit/hal/metadata.py
@@ -72,7 +72,6 @@ HAL_TOPIC_CHOICES = [
     ('SPI', __('Engineering sciences')),
     ('STAT', __('Statistics')),
     ('QFIN', __('Economy and quantitative finance')),
-    ('OTHER', __('Other')),
   ]
 
 

--- a/deposit/hal/protocol.py
+++ b/deposit/hal/protocol.py
@@ -113,6 +113,8 @@ class HALProtocol(RepositoryProtocol):
         else:
             topic_text = self.paper.title
         data['topic'] = self.predict_topic(topic_text)
+        if data['topic'] == 'OTHER':
+            del data['topic']
 
         # Depositing author
         most_similar_idx = None

--- a/deposit/hal/tests.py
+++ b/deposit/hal/tests.py
@@ -135,7 +135,8 @@ class HALProtocolTest(ProtocolTest):
 
     def test_topic_set_to_other(self):
         """
-        Submit a journal article
+        Submit a journal article with "OTHER" as topic,
+        which is forbidden by HAL
         """
         p = Paper.create_by_doi('10.1016/j.agee.2004.10.001')
         p.authors_list = [p.authors_list[0]]
@@ -144,7 +145,7 @@ class HALProtocolTest(ProtocolTest):
              topic='OTHER',
              depositing_author=0,
              affiliation=128940)
-        self.assertEqualOrLog(r.status, 'faked')
+        self.assertEqualOrLog(r.status, 'failed')
 
 
     def test_keywords(self):

--- a/deposit/hal/tests.py
+++ b/deposit/hal/tests.py
@@ -139,17 +139,19 @@ class HALProtocolTest(ProtocolTest):
         which is forbidden by HAL
         """
         p = Paper.create_by_doi('10.1016/j.agee.2004.10.001')
-        enabled = self.proto.init_deposit(p, self.user)
+        self.proto.init_deposit(p, self.user)
 
+        # the user is presented with initial data
         args = self.proto.get_form_initial_data()
+        # they fill the form with an invalid topic
         form_fields = {'abstract':'here is my great result',
              'topic':'OTHER',
              'depositing_author':0,
              'affiliation':128940}
         args.update(form_fields)
 
-        form = self.proto.get_bound_form(args)
         # the form should reject the "OTHER" topic
+        form = self.proto.get_bound_form(args)
         self.assertFalse(form.is_valid())
 
     def test_keywords(self):

--- a/deposit/hal/tests.py
+++ b/deposit/hal/tests.py
@@ -139,14 +139,18 @@ class HALProtocolTest(ProtocolTest):
         which is forbidden by HAL
         """
         p = Paper.create_by_doi('10.1016/j.agee.2004.10.001')
-        p.authors_list = [p.authors_list[0]]
-        r = self.dry_deposit(p,
-             abstract='here is my great result',
-             topic='OTHER',
-             depositing_author=0,
-             affiliation=128940)
-        self.assertEqualOrLog(r.status, 'failed')
+        enabled = self.proto.init_deposit(p, self.user)
 
+        args = self.proto.get_form_initial_data()
+        form_fields = {'abstract':'here is my great result',
+             'topic':'OTHER',
+             'depositing_author':0,
+             'affiliation':128940}
+        args.update(form_fields)
+
+        form = self.proto.get_bound_form(args)
+        # the form should reject the "OTHER" topic
+        self.assertFalse(form.is_valid())
 
     def test_keywords(self):
         """

--- a/deposit/hal/tests.py
+++ b/deposit/hal/tests.py
@@ -133,6 +133,20 @@ class HALProtocolTest(ProtocolTest):
              affiliation=128940)
         self.assertEqualOrLog(r.status, 'faked')
 
+    def test_topic_set_to_other(self):
+        """
+        Submit a journal article
+        """
+        p = Paper.create_by_doi('10.1016/j.agee.2004.10.001')
+        p.authors_list = [p.authors_list[0]]
+        r = self.dry_deposit(p,
+             abstract='here is my great result',
+             topic='OTHER',
+             depositing_author=0,
+             affiliation=128940)
+        self.assertEqualOrLog(r.status, 'faked')
+
+
     def test_keywords(self):
         """
         Keywords are mandatory


### PR DESCRIPTION
It is in the list of their topics but their deposit does not seem to accept it, so we remove it from our form.