### PR TITLE
Specify required type field in "preprints" OSF API

### DIFF
--- a/deposit/osf/protocol.py
+++ b/deposit/osf/protocol.py
@@ -523,6 +523,7 @@ class OSFProtocol(RepositoryProtocol):
             }
 
             public_preprint = {
+                "type": "preprints",
                 "data": {
                     "id": preprint_id,
                     "attributes": {

--- a/deposit/osf/protocol.py
+++ b/deposit/osf/protocol.py
@@ -332,6 +332,7 @@ class OSFProtocol(RepositoryProtocol):
         # -----------------------------------------------
         min_preprint_structure = {
             "data": {
+                "type" : "preprints",
                 "attributes": {
                     "doi": paper_doi,
                     "subjects": subjects


### PR DESCRIPTION
Per https://developer.osf.io/#operation/preprints_create

https://github.com/dissemin/dissemin/issues/537