### PR TITLE
Fix error when trying to deposit paper with invalid record URL

### DIFF
--- a/deposit/osf/protocol.py
+++ b/deposit/osf/protocol.py
@@ -59,7 +59,7 @@ class OSFProtocol(RepositoryProtocol):
         """
         super(OSFProtocol, self).init_deposit(paper, user)
         for r in paper.oairecords:
-            domain = extract_domain(r.splash_url)
+            domain = extract_domain(r.splash_url) or ''
             if domain.endswith('osf.io'):
                 return False
         return (True)

--- a/deposit/zenodo/protocol.py
+++ b/deposit/zenodo/protocol.py
@@ -54,7 +54,7 @@ class ZenodoProtocol(RepositoryProtocol):
         """
         super(ZenodoProtocol, self).init_deposit(paper, user)
         for r in paper.oairecords:
-            domain = extract_domain(r.splash_url)
+            domain = extract_domain(r.splash_url) or ''
             if domain.endswith('zenodo.org'):
                 return False
         return True


### PR DESCRIPTION
Hi,

`extract_domain` returns `None` if no domain is matched. This lead to
exceptions being raised
https://sentry.io/dissemin/dissemin/issues/470352188/.

Not sure what is the value of `r.splash_url` [here](https://github.com/dissemin/dissemin/blob/master/deposit/zenodo/protocol.py#L57). There might be an extra bug with either this `r.splash_url` being an invalid URL or `extract_domain` failing to extract the domain. Not sure how to check this :/

Best,