### PR TITLE
Fix an issue with search results

### DIFF
--- a/statistics/models.py
+++ b/statistics/models.py
@@ -159,7 +159,7 @@ class BareAccessStatistics(object):
         qs = qs.aggregations({
          "status": {"terms": {"field": "combined_status_exact"}},
         })
-        aggregations = qs.get_aggregation_results()
+        aggregations = qs.get_aggregation_results() or {}
         status = aggregations.get('status', {'buckets':[]})
         buckets = {
             bucket['key']: bucket['doc_count']


### PR DESCRIPTION
Do not show an error page when `aggregations` are not defined for a
search query. Typically for weird (SQL injection attempts) queries such
as

```
luis angel moreno anselmi" or (1,2)=(select*from(select name_const(CHAR(111,108,111,108,111,115,104,101,114),1),name_const(CHAR(111,108,111,108,111,115,104,101,114),1))a) -- "x"="x
```

Fixes https://sentry.io/dissemin/dissemin/issues/309734257/.