### PR TITLE
Fix issues with accents in the ORCID interface

### DIFF
--- a/papers/testbibtex.py
+++ b/papers/testbibtex.py
@@ -15,23 +15,117 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
-
-
 from __future__ import unicode_literals
 
 import unittest
 
-from papers.bibtex import parse_authors_list
+from papers.bibtex import parse_authors_list, parse_bibtex
 
 
 class ParseAuthorsListTest(unittest.TestCase):
-
     def test_simple(self):
-        self.assertEqual(parse_authors_list('Claire Toffano-Nioche and Daniel Gautheret and Fabrice Leclerc'),
-                         [('Claire', 'Toffano-Nioche'), ('Daniel', 'Gautheret'), ('Fabrice', 'Leclerc')])
+        record = {
+            'author': 'Claire Toffano-Nioche and Daniel Gautheret and Fabrice Leclerc'
+        }
+        self.assertEqual(
+            parse_authors_list(record),
+            {
+                'author': [
+                    ('Claire', 'Toffano-Nioche'),
+                    ('Daniel', 'Gautheret'),
+                    ('Fabrice', 'Leclerc')
+                ]
+            }
+        )
 
     def test_etal(self):
-        self.assertEqual(parse_authors_list('Claire Toffano-Nioche and et al.'),
-                         [('Claire', 'Toffano-Nioche')])
+        record = {
+            'author': 'Claire Toffano-Nioche and et al.'
+        }
+        self.assertEqual(
+            parse_authors_list(record),
+            {
+                'author': [('Claire', 'Toffano-Nioche')]
+            }
+        )
+
+    def test_others(self):
+        record = {
+            'author': 'Claire Toffano-Nioche and others'
+        }
+        self.assertEqual(
+            parse_authors_list(record),
+            {
+                'author': [('Claire', 'Toffano-Nioche')]
+            }
+        )
+
+
+class ParseBibtexTest(unittest.TestCase):
+    def test_parse_bibtex(self):
+        bibtex = """@misc{ Nobody06,
+    author = "Orti, E. and Bredas, J.L. and Clarisse, C. and others",
+    title = "My Article",
+    year = "2006" }
+        """
+        self.assertEqual(
+            parse_bibtex(bibtex),
+            {
+                'ENTRYTYPE': 'misc',
+                'ID': 'Nobody06',
+                'author': [
+                    ('E.', 'Orti'),
+                    ('J. L.', 'Bredas'),
+                    ('C.', 'Clarisse')
+                ],
+                'title': 'My Article',
+                'year': '2006'
+            }
+        )
+
+    def test_parse_bibtex_unicode_accents(self):
+        """
+        See https://github.com/dissemin/dissemin/issues/362
+        """
+        bibtex = """@misc{ Nobody06,
+    author = "Adrià Martin Mor",
+    title = "My Article",
+    year = "2006" }
+        """
+        self.assertEqual(
+            parse_bibtex(bibtex),
+            {
+                'ENTRYTYPE': 'misc',
+                'ID': 'Nobody06',
+                'author': [(u'Adrià Martin', u'Mor')],
+                'title': 'My Article',
+                'year': '2006'
+            }
+        )
+
+    def test_parse_bibtex_latex_accents(self):
+        """
+        See https://github.com/dissemin/dissemin/issues/362
+        """
+        bibtex = r"""@misc{Nobody06,
+    author = "Adri{\`{a}} Mart{\'{\i}}n Mor and Alessandro Beccu",
+    title = "My Article",
+    year = "2006" }
+        """
+        print(parse_bibtex(bibtex)['author'][0][0])
+        self.assertEqual(
+            parse_bibtex(bibtex),
+            {
+                'ENTRYTYPE': 'misc',
+                'ID': 'Nobody06',
+                'author': [
+                    ('Adrià Martín', 'Mor'),
+                    ('Alessandro', 'Beccu')
+                ],
+                'title': 'My Article',
+                'year': '2006'
+            }
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e git://github.com/swordapp/python-client-sword2#egg=sword2
 -e git://github.com/wetneb/pyoai.git@any_metadataPrefix#egg=pyoai
 PyPDF2
-bibtexparser
+bibtexparser>=1.1.0
 celery[redis]
 cryptography
 czipfile


### PR DESCRIPTION
Hi,

This makes use of an updated version of Python-bibtexparser in order to
defer accents parsing to it. Accents should now be correctly parsed in
names.

I added some tests, hoping to cover these cases.

This is a fix for #362.