### PR TITLE
Fix incorrect redirection when no HTTP REFERER (sic) is provided

### DIFF
--- a/papers/testpages.py
+++ b/papers/testpages.py
@@ -78,6 +78,9 @@ class RenderingTest(django.test.TestCase):
 
     def checkPermanentRedirect(self, *args, **kwargs):
         self.assertEqual(self.getPage(*args, **kwargs).status_code, 301)
+        
+    def checkTemporaryRedirect(self, *args, **kwargs):
+        self.assertEqual(self.getPage(*args, **kwargs).status_code, 302)
 
     def check404(self, *args, **kwargs):
         self.assertEqual(self.getPage(*args, **kwargs).status_code, 404)
@@ -107,6 +110,10 @@ class PaperPagesTest(RenderingTest):
     def test_researcher_orcid(self):
         self.checkPermanentRedirect(
             'researcher-by-orcid', kwargs={'orcid': self.r4.orcid})
+        
+    def test_update_researcher(self):
+        self.checkTemporaryRedirect(
+            'refetch-researcher', kwargs={'pk':self.r4.id})
 
     def test_researcher_no_name(self):
         # this ORCID profile does not have a public name:

--- a/papers/views.py
+++ b/papers/views.py
@@ -333,10 +333,7 @@ def refetchResearcher(request, pk):
     from backend.tasks import fetch_everything_for_researcher
     fetch_everything_for_researcher.delay(pk=pk)
 
-    if 'HTTP_REFERER' in request.META:
-        return redirect(request.META['HTTP_REFERER'])
-    else:
-        return redirect(reverse('researcher', researcher=pk))
+    return redirect(reverse('researcher', researcher=pk))
 
 
 @user_passes_test(is_authenticated)


### PR DESCRIPTION
Should fix latest SEntry notification, if I did not mess up with Django URLs.