### PR TITLE
Fix Vagrant VM after migration to Python3

### DIFF
--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -24,7 +24,7 @@ apt-get install -y build-essential curl screen libxml2-dev libxslt1-dev gettext 
         pwgen git
 
 # We install Python
-apt-get install -y python python-dev python-virtualenv virtualenv
+apt-get install -y python3 python3-dev python3-virtualenv virtualenv
 # We install PostgreSQL now
 apt-get install -y postgresql postgresql-server-dev-all postgresql-client
 # We install ElasticSearch now
@@ -59,13 +59,15 @@ systemctl restart elasticsearch
 # We install some dev tools (tmux and vim)
 apt-get install -y tmux vim-nox
 # We create a virtualenv for Dissemin
-virtualenv /dissemin/.vm_venv --no-site-packages -p $(which python2.7)
+virtualenv /dissemin/.vm_venv --no-site-packages -p $(which python3)
 
 # Update setuptools
 # Fix for a weird setuptools bug, see
 # https://github.com/pypa/setuptools/issues/299#issuecomment-441898332
 /dissemin/.vm_venv/bin/pip uninstall -y setuptools
 /dissemin/.vm_venv/bin/pip install --upgrade setuptools
+# Update pip
+/dissemin/.vm_venv/bin/pip install --upgrade pip
 
 # We install dependencies in the virtualenv
 req_files=(requirements.txt requirements-dev.txt)
@@ -184,7 +186,7 @@ tmux set-option -t $_SNAME set-remain-on-exit on
 # Django development server
 tmux new-window -t $_SNAME -n django -c '/dissemin' -d '/dissemin/.vm_venv/bin/python /dissemin/manage.py runserver 0.0.0.0:8080'
 # Celery backend
-tmux new-window -t $_SNAME -n celery -c '/dissemin' -d '/dissemin/.vm_venv/bin/celery --app=dissemin.celery:app worker -B -l INFO'
+tmux new-window -t $_SNAME -n celery -c '/dissemin' -d 'PYTHONPATH=/dissemin /dissemin/.vm_venv/bin/celery --app=dissemin.celery:app worker -B -l INFO'
 # Super user prompt
 tmux new-window -t $_SNAME -n superuser -c '/dissemin' -d '/dissemin/.vm_venv/bin/python /dissemin/manage.py createsuperuser'
 EOF


### PR DESCRIPTION
Remaining issue:

```
$ python /dissemin/manage.py update_index

/dissemin/.vm_venv/lib/python3.4/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
Indexing 4 publishers
[ERROR/MainProcess] Failed indexing 1 - 4 (retry 5/5): Invalid template library specified. ImportError raised when trying to load 'papers.templatetags.choice_tags': bad magic number in 'papers.templatetags.choice_tags': b'\x03\xf3\r\n' (pid 7670): Invalid template library specified. ImportError raised when trying to load 'papers.templatetags.choice_tags': bad magic number in 'papers.templatetags.choice_tags': b'\x03\xf3\r\n'
Traceback (most recent call last):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 65, in __getitem__
    return self._engines[alias]
KeyError: 'django'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 126, in get_package_libraries
    module = import_module(entry[1])
  File "/dissemin/.vm_venv/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1467, in exec_module
  File "<frozen importlib._bootstrap>", line 1677, in get_code
  File "<frozen importlib._bootstrap>", line 624, in _validate_bytecode_header
ImportError: bad magic number in 'papers.templatetags.choice_tags': b'\x03\xf3\r\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 97, in do_update
    backend.update(index, current_qs, commit=commit)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/backends/elasticsearch_backend.py", line 168, in update
    prepped_data = index.full_prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/indexes.py", line 208, in full_prepare
    self.prepared_data = self.prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/indexes.py", line 199, in prepare
    self.prepared_data[field.index_fieldname] = field.prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 206, in prepare
    return self.convert(super(CharField, self).prepare(obj))
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 83, in prepare
    return self.prepare_template(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 183, in prepare_template
    t = loader.select_template(template_names)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/loader.py", line 44, in select_template
    engines = _engine_list(using)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/loader.py", line 72, in _engine_list
    return engines.all() if using is None else [engines[using]]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 89, in all
    return [self[alias] for alias in self]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 89, in <listcomp>
    return [self[alias] for alias in self]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 80, in __getitem__
    engine = engine_cls(params)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 30, in __init__
    options['libraries'] = self.get_templatetag_libraries(libraries)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 48, in get_templatetag_libraries
    libraries = get_installed_libraries()
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 113, in get_installed_libraries
    for name in get_package_libraries(pkg):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 130, in get_package_libraries
    "trying to load '%s': %s" % (entry[1], e)
django.template.library.InvalidTemplateLibrary: Invalid template library specified. ImportError raised when trying to load 'papers.templatetags.choice_tags': bad magic number in 'papers.templatetags.choice_tags': b'\x03\xf3\r\n'
[ERROR/MainProcess] Error updating publishers using default
Traceback (most recent call last):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 65, in __getitem__
    return self._engines[alias]
KeyError: 'django'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 126, in get_package_libraries
    module = import_module(entry[1])
  File "/dissemin/.vm_venv/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1467, in exec_module
  File "<frozen importlib._bootstrap>", line 1677, in get_code
  File "<frozen importlib._bootstrap>", line 624, in _validate_bytecode_header
ImportError: bad magic number in 'papers.templatetags.choice_tags': b'\x03\xf3\r\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 230, in handle
    self.update_backend(label, using)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 276, in update_backend
    last_max_pk=max_pk)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 97, in do_update
    backend.update(index, current_qs, commit=commit)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/backends/elasticsearch_backend.py", line 168, in update
    prepped_data = index.full_prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/indexes.py", line 208, in full_prepare
    self.prepared_data = self.prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/indexes.py", line 199, in prepare
    self.prepared_data[field.index_fieldname] = field.prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 206, in prepare
    return self.convert(super(CharField, self).prepare(obj))
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 83, in prepare
    return self.prepare_template(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 183, in prepare_template
    t = loader.select_template(template_names)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/loader.py", line 44, in select_template
    engines = _engine_list(using)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/loader.py", line 72, in _engine_list
    return engines.all() if using is None else [engines[using]]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 89, in all
    return [self[alias] for alias in self]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 89, in <listcomp>
    return [self[alias] for alias in self]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 80, in __getitem__
    engine = engine_cls(params)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 30, in __init__
    options['libraries'] = self.get_templatetag_libraries(libraries)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 48, in get_templatetag_libraries
    libraries = get_installed_libraries()
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 113, in get_installed_libraries
    for name in get_package_libraries(pkg):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 130, in get_package_libraries
    "trying to load '%s': %s" % (entry[1], e)
django.template.library.InvalidTemplateLibrary: Invalid template library specified. ImportError raised when trying to load 'papers.templatetags.choice_tags': bad magic number in 'papers.templatetags.choice_tags': b'\x03\xf3\r\n'
Traceback (most recent call last):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 65, in __getitem__
    return self._engines[alias]
KeyError: 'django'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 126, in get_package_libraries
    module = import_module(entry[1])
  File "/dissemin/.vm_venv/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1467, in exec_module
  File "<frozen importlib._bootstrap>", line 1677, in get_code
  File "<frozen importlib._bootstrap>", line 624, in _validate_bytecode_header
ImportError: bad magic number in 'papers.templatetags.choice_tags': b'\x03\xf3\r\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/dissemin/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 230, in handle
    self.update_backend(label, using)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 276, in update_backend
    last_max_pk=max_pk)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/management/commands/update_index.py", line 97, in do_update
    backend.update(index, current_qs, commit=commit)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/backends/elasticsearch_backend.py", line 168, in update
    prepped_data = index.full_prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/indexes.py", line 208, in full_prepare
    self.prepared_data = self.prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/indexes.py", line 199, in prepare
    self.prepared_data[field.index_fieldname] = field.prepare(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 206, in prepare
    return self.convert(super(CharField, self).prepare(obj))
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 83, in prepare
    return self.prepare_template(obj)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/haystack/fields.py", line 183, in prepare_template
    t = loader.select_template(template_names)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/loader.py", line 44, in select_template
    engines = _engine_list(using)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/loader.py", line 72, in _engine_list
    return engines.all() if using is None else [engines[using]]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 89, in all
    return [self[alias] for alias in self]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 89, in <listcomp>
    return [self[alias] for alias in self]
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/utils.py", line 80, in __getitem__
    engine = engine_cls(params)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 30, in __init__
    options['libraries'] = self.get_templatetag_libraries(libraries)
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 48, in get_templatetag_libraries
    libraries = get_installed_libraries()
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 113, in get_installed_libraries
    for name in get_package_libraries(pkg):
  File "/dissemin/.vm_venv/lib/python3.4/site-packages/django/template/backends/django.py", line 130, in get_package_libraries
    "trying to load '%s': %s" % (entry[1], e)
django.template.library.InvalidTemplateLibrary: Invalid template library specified. ImportError raised when trying to load 'papers.templatetags.choice_tags': bad magic number in 'papers.templatetags.choice_tags': b'\x03\xf3\r\n'
```

Have you seen this as well @wetneb ?