### PR TITLE
More documentation

### DIFF
--- a/doc/sphinx/deploying.rst
+++ b/doc/sphinx/deploying.rst
@@ -21,7 +21,7 @@ Production settings
 
 As any Django website, Dissemin can be served by various web servers.
 These settings are not specific to dissemin itself so you should refer
-to `the relevant Django documentation <https://docs.djangoproject.com/en/1.11/howto/deployment/>`_.
+to `the relevant Django documentation <https://docs.djangoproject.com/en/2.2/howto/deployment/>`_.
 
 No matter what web server you use,
 you need to run ``python manage.py collectstatic`` to copy the static files from
@@ -59,7 +59,7 @@ to load MathJax from. In the example below, this would be
 Apache with WSGI
 ----------------
 
-Here is a sample VirtualHost, assuming that the root of the Dissemin source code is at ``/home/dissemin``.::
+Here is a sample VirtualHost, assuming that the root of the Dissemin source code is at ``/home/dissemin`` and you use ``python3.6``.::
 
     <VirtualHost *:80>
             ServerAdmin webmaster@localhost
@@ -93,7 +93,7 @@ Here is a sample VirtualHost, assuming that the root of the Dissemin source code
             # Path to the WSGI application for the website
             WSGIScriptAlias / /home/dissemin/dissemin/wsgi.py
             # Python path for the application
-            WSGIDaemonProcess dissemin.myuni.edu python-path=/home/dissemin:/home/dissemin/.virtualenv/lib/python2.7/site-packages
+            WSGIDaemonProcess dissemin.myuni.edu python-path=/home/dissemin:/home/dissemin/.virtualenv/lib/python3.6/site-packages
 
             WSGIProcessGroup dissemin.myuni.edu
 

--- a/doc/sphinx/install.rst
+++ b/doc/sphinx/install.rst
@@ -55,12 +55,12 @@ Installation instructions for the web frontend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First, install the following dependencies (debian packages)
-``postgresql postgresql-server-dev-all postgresql-client python-virtualenv build-essential libxml2-dev libxslt1-dev python-dev gettext libjpeg-dev libffi-dev``
+``postgresql postgresql-server-dev-all postgresql-client python3-venv build-essential libxml2-dev libxslt1-dev python3-dev gettext libjpeg-dev libffi-dev``
 
 Then, build a virtual environment to isolate all the python
 dependencies::
 
-   virtualenv .virtualenv
+   python3 -m venv .virtualenv
    source .virtualenv/bin/activate
    pip install --upgrade setuptools
    pip install --upgrade pip

--- a/doc/sphinx/localization.rst
+++ b/doc/sphinx/localization.rst
@@ -7,7 +7,7 @@ Translations are hosted at `TranslateWiki
 <https://translatewiki.net/wiki/Translating:Dissemin>`_, for an easy-to-use
 interface for translations and statistics.
 
-We use `Django's standard localization system <https://docs.djangoproject.com/en/1.11/topics/i18n/>`_, based on i18n.
+We use `Django's standard localization system <https://docs.djangoproject.com/en/2.2/topics/i18n/>`_, based on i18n.
 This lets us translate strings in various places:
 
 * in Python code, use ``_("some translatable text")``, where ``_`` is imported by ``from django.utils.translation import ugettext_lazy as _``

--- a/doc/sphinx/repository_interfaces.rst
+++ b/doc/sphinx/repository_interfaces.rst
@@ -177,7 +177,7 @@ Dissemin does not always provide? We need to add a field in the deposit form
 to let the user fill this gap.
 
 Fortunately, Django has `a very convenient interface to deal with
-forms <https://docs.djangoproject.com/en/1.9/topics/forms/#building-a-form-in-django>`_,
+forms <https://docs.djangoproject.com/en/2.2/topics/forms/#building-a-form-in-django>`_,
 so it should be quite straightforward to add the fields you need.
 
 Let's say that the repository we want to deposit into takes two additional
@@ -207,7 +207,7 @@ All we need to do is to define a form with these two fields::
             label=_('Topic'), # the label that will be displayed on the field
             choices=MYREPO_TOPIC_CHOICES, # the possible choices for the user
             required=True, # is this field mandatory?
-            # other arguments are possible, see https://docs.djangoproject.com/en/1.9/ref/forms/fields/
+            # other arguments are possible, see https://docs.djangoproject.com/en/2.2/ref/forms/fields/
             )
 
         comment = forms.CharField(


### PR DESCRIPTION
With the migration to Python3 and Django2 there were some documentation updates necessary.

Also concerning  #597 there is now a documentation for celery and celerybeat running as daemon.