### PR TITLE
Only update stats for publishers and all papers

### DIFF
--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -36,9 +36,7 @@ from papers.errors import MetadataSourceException
 from papers.models import Paper
 from papers.models import PaperWorld
 from papers.models import Researcher
-from papers.models import Institution
 from papers.models import OaiSource
-from publishers.models import Journal
 from publishers.models import Publisher
 from backend.oai import OaiPaperSource
 
@@ -127,10 +125,6 @@ def update_all_stats():
     """
     AccessStatistics.update_all_stats(PaperWorld)
     AccessStatistics.update_all_stats(Publisher)
-    AccessStatistics.update_all_stats(Journal)
-    AccessStatistics.update_all_stats(Institution)
-    #AccessStatistics.update_all_stats(Researcher)
-    #AccessStatistics.update_all_stats(Department)
 
 
 @shared_task(name='update_crossref')

--- a/statistics/models.py
+++ b/statistics/models.py
@@ -34,7 +34,7 @@ which computes the status of a particular paper.
 """
 
 
-
+from time import sleep
 from django.db import models
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
@@ -271,13 +271,15 @@ class AccessStatistics(models.Model, BareAccessStatistics):
         self.save()
 
     @classmethod
-    def update_all_stats(self, _class):
+    def update_all_stats(self, _class, delay=1):
         """
         Update all statistics for the objects of a given class.
         This calls the underlying :py:meth:`!update_stats()` function for each instance
         of the model.
         """
         for x in _class.objects.all():
+            if delay:
+                sleep(delay)
             x.update_stats()
 
     class Meta:


### PR DESCRIPTION
and slow down the stats refreshing task.

This should fix the load issues.