### PR TITLE
Fix year formatting, no thousands separators

### DIFF
--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -123,6 +123,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.humanize',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
@@ -310,7 +311,6 @@ django.conf.locale.LANG_INFO = LANG_INFO
 TIME_ZONE = 'Europe/Paris'
 USE_I18N = True
 USE_L10N = True
-USE_THOUSAND_SEPARATOR = True
 USE_TZ = True
 LOCALE_PATHS = (os.path.join(BASE_DIR, 'locale'),)
 

--- a/statistics/templates/statistics/pie_without_object.html
+++ b/statistics/templates/statistics/pie_without_object.html
@@ -1,4 +1,5 @@
 {% load get_pie_data %}
+{% load humanize %}
 {% load i18n %}
 <div class="access-statistics" id="statspie_n{{ stats_counter }}">
   <div class="statspie_graph"></div>
@@ -23,7 +24,8 @@
         <span class="stats_caption_label">
           <span class="stats_caption_label_text">{{ status.choice_label }}</span>
           <span class="detail">
-            {% cycle stats.num_oa stats.num_ok stats.num_couldbe stats.num_unk stats.num_closed %}
+            {% cycle stats.num_oa stats.num_ok stats.num_couldbe stats.num_unk stats.num_closed as stats_number silent %}
+            {{ stats_number | intcomma }}
           </span>
         </span>
       {% if combined_status_form %}


### PR DESCRIPTION
My change from yesterday was actually too simple and was also affecting the years :/

![Screenshot_2019-03-15 Papiers - Dissemin](https://user-images.githubusercontent.com/3856586/54450434-a902ce80-4750-11e9-8b4a-5efd205acc9e.png)

I think the best approach is probably to default to not using thousands separators and explicitly force them for the statistics template. This PR should do it. However, I could not test it so not to be merged without explicitly checking it. I can check it and revise later.