### PR TITLE
Remove references to RoMEO cache

### DIFF
--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -94,10 +94,6 @@ DOI_PROXY_SUPPORTS_BATCH = True
 CROSSREF_MAILTO = 'dev@dissem.in'
 CROSSREF_USER_AGENT = 'Dissemin/0.1 (https://dissem.in/; mailto:dev@dissem.in)'
 
-### RoMEO proxy ###
-# Set this to 'romeo-cache.dissem.in' for our own cache of their API
-ROMEO_API_DOMAIN = 'www.sherpa.ac.uk'
-
 ### Paper deposits ###
 # Max size of the PDFs (in bytes)
 # 2.5MB - 2621440

--- a/dissemin/settings/sphinx.py
+++ b/dissemin/settings/sphinx.py
@@ -59,8 +59,6 @@ DOI_PROXY_SUPPORTS_BATCH = True
 CROSSREF_MAILTO = 'dev@dissem.in'
 CROSSREF_USER_AGENT = 'Dissemin/0.1 (https://dissem.in/; mailto:dev@dissem.in)'
 
-ROMEO_API_DOMAIN = 'romeo-cache.dissem.in'
-
 DEPOSIT_MAX_FILE_SIZE = 1024*1024*200  # 20 MB
 URL_DEPOSIT_DOWNLOAD_TIMEOUT = 10
 

--- a/publishers/romeo.py
+++ b/publishers/romeo.py
@@ -43,9 +43,8 @@ from publishers.models import PublisherRestrictionDetail
 
 class RomeoAPI(object):
 
-    def __init__(self, domain=settings.ROMEO_API_DOMAIN, api_key=settings.ROMEO_API_KEY):
-        self.domain = domain
-        self.base_url = 'http://'+domain+'/romeo/api29.php'
+    def __init__(self, api_key=settings.ROMEO_API_KEY):
+        self.base_url = 'http://www.sherpa.ac.uk/romeo/api29.php'
         self.api_key = api_key
 
     def perform_romeo_query(self, search_terms):
@@ -211,7 +210,7 @@ class RomeoAPI(object):
         """
         Fetches all the journals from RoMEO.
         """
-        r = requests.get('http://{}/downloads/journal-title-issns.php'.format(self.domain),
+        r = requests.get('http://www.sherpa.ac.uk/downloads/journal-title-issns.php',
                          {'ak':self.api_key, 'format':'tsv'})
         # r.encoding = 'ISO-8859-1'
         headers = None
@@ -262,7 +261,7 @@ class RomeoAPI(object):
         This returns a dict: the dates can be accessed via the 'publishers' and 'journals'
         keys.
         """
-        r = requests.get('http://{}/downloads/download-dates.php'.format(self.domain),
+        r = requests.get('http://www.sherpa.ac.uk/downloads/download-dates.php',
                          {'ak':self.api_key, 'format':'xml'})
         parser = ET.XMLParser(encoding='ISO-8859-1')
         root = ET.parse(BytesIO(r.content), parser)


### PR DESCRIPTION
The RoMEO cache is no longer needed now that we fetch updates via their dump API.