### PR TITLE
WIP: Setting up logging

### DIFF
--- a/backend/oai.py
+++ b/backend/oai.py
@@ -155,7 +155,7 @@ class OaiPaperSource(PaperSource):  # TODO: this should not inherit from PaperSo
                     saved = Paper.from_bare(paper)
                 return saved
             except ValueError:
-                logger.exception("Ignoring invalid paper with header %s" % header.idendifier())
+                logger.exception("Ignoring invalid paper with header %s" % header.identifier())
 
     def process_records(self, listRecords, format):
         """

--- a/backend/orcid.py
+++ b/backend/orcid.py
@@ -168,7 +168,7 @@ class OrcidPaperSource(PaperSource):
             if profile is None:
                 profile = OrcidProfile(orcid_id=orcid_id)
         except MetadataSourceException:
-            logger.exception()
+            logger.exception("ORCID Profile Error")
             return
 
         # As we have fetched the profile, let's update the Researcher

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -40,7 +40,7 @@ from papers.models import OaiSource
 from publishers.models import Publisher
 from backend.oai import OaiPaperSource
 
-logger = get_task_logger(__name__)
+logger = get_task_logger('dissemin.' + __name__)
 
 
 def update_researcher_task(r, task_name):
@@ -97,7 +97,7 @@ def fetch_everything_for_researcher(pk):
 
 def refetch_researchers(start_time=timezone.now() - timedelta(days=30*6)):
     for r in Researcher.objects.filter(last_harvest__gt=start_time).order_by('last_harvest'):
-        print(r.url)
+        logger.info(r.url)
         fetch_everything_for_researcher(r.pk)
 
 
@@ -114,7 +114,7 @@ def consolidate_paper(pk):
             if pub.description and len(pub.description) > len(abstract):
                 break
     except Paper.DoesNotExist:
-        print("consolidate_paper: unknown paper %d" % pk)
+        logger.exception("consolidate_paper: unknown paper %d" % pk)
 
 
 @shared_task(name='update_all_stats')

--- a/backend/translators.py
+++ b/backend/translators.py
@@ -32,6 +32,9 @@ from papers.utils import tolerant_datestamp_to_datetime
 from papers.utils import valid_publication_date
 from oaipmh.error import DatestampError
 from backend.pubtype_translations import OAI_PUBTYPE_TRANSLATIONS
+import logging
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 class OaiTranslator(object):
     """
@@ -135,7 +138,7 @@ class OAIDCTranslator(OaiTranslator):
 
         # - title
         if not metadata.get('title') or not authors or not pubdate:
-            #print "no title, authors, or pubdate"
+            logger.debug("No title, authors or pubdate")
             return
 
         # Create paper and record
@@ -144,7 +147,7 @@ class OAIDCTranslator(OaiTranslator):
             self.add_oai_record(header, metadata, paper)
             return paper
         except ValueError as e:
-            print("Warning, OAI record "+header.identifier()+" skipped:\n"+str(e))
+            logger.warning("OAI record "+header.identifier()+" skipped:\n", e, exc_info=True)
             paper.update_availability()
 
     def add_oai_record(self, header, metadata, paper):

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -22,6 +22,7 @@
 
 from time import sleep
 
+import logging
 import requests
 import requests.exceptions
 
@@ -29,6 +30,8 @@ from dissemin.settings import redis_client
 from memoize import memoize
 from papers.errors import MetadataSourceException
 
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 # Run a task at most one at a time
 
@@ -83,8 +86,7 @@ def urlopen_retry(url, **kwargs):  # data, timeout, retries, delay, backoff):
     except requests.exceptions.RequestException as e:
         raise MetadataSourceException('Request error: '+str(e))
 
-    print("Retrying in "+str(delay)+" seconds...")
-    print("URL: "+url)
+    logger.info("Retrying in "+str(delay)+" seconds with url "+url)
     sleep(delay)
     return urlopen_retry(url,
                          data=data,

--- a/deposit/models.py
+++ b/deposit/models.py
@@ -21,6 +21,7 @@
 
 
 
+import logging
 from caching.base import CachingManager
 from caching.base import CachingMixin
 from deposit.registry import protocol_registry
@@ -33,6 +34,8 @@ from papers.models import Paper
 from papers.models import OaiRecord
 from papers.models import UPLOAD_TYPE_CHOICES
 from upload.models import UploadedPDF
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 DEPOSIT_STATUS_CHOICES = [
    ('failed', _('Failed')), # we failed to deposit the paper
@@ -102,7 +105,7 @@ class Repository(models.Model, CachingMixin):
         """
         cls = protocol_registry.get(self.protocol)
         if cls is None:
-            print("Warning: protocol not found: "+str(self.protocol))
+            logger.warning("Protocol not found: "+str(self.protocol))
             return
         return cls(self)
 

--- a/deposit/registry.py
+++ b/deposit/registry.py
@@ -22,6 +22,7 @@
 
 
 
+import logging
 import re
 
 from django.conf import settings
@@ -31,6 +32,8 @@ try:
 except ImportError:
     from django.utils import importlib
 
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 protocol_module_re = re.compile(r'deposit.\w+')
 
@@ -54,9 +57,8 @@ class ProtocolRegistry(object):
                 if protocol_module_re.match(app):
                     try:
                         importlib.import_module(app+'.protocol')
-                    except ImportError as e:
-                        print("ImportError in "+app+'.protocol')
-                        print(e)
+                    except ImportError:
+                        logger.exception()
         self.loaded = True
 
 protocol_registry = ProtocolRegistry()

--- a/deposit/tasks.py
+++ b/deposit/tasks.py
@@ -20,10 +20,12 @@
 
 
 
-
+import logging
 from celery import shared_task
 from backend.utils import run_only_once
 from deposit.models import DepositRecord
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 @shared_task(name='refresh_deposit_statuses')
 @run_only_once('refresh_deposit_statuses')
@@ -32,7 +34,7 @@ def refresh_deposit_statuses():
     # ignore 'failed' and 'faked' statuses
     for d in DepositRecord.objects.filter(status__in=
             ['pending','published','refused','deleted']).select_related('repository'):
-        print(d.status)
+        logger.info(d.status)
         protocol = d.repository.get_implementation()
         if protocol:
             protocol.refresh_deposit_status(d)

--- a/deposit/views.py
+++ b/deposit/views.py
@@ -20,6 +20,7 @@
 
 
 import os
+import logging
 
 from crispy_forms.templatetags.crispy_forms_filters import as_crispy_form
 from crispy_forms.utils import render_crispy_form
@@ -42,6 +43,8 @@ from papers.models import Paper
 from papers.user import is_authenticated
 from ratelimit.decorators import ratelimit
 
+logger = logging.getLogger('dissemin.' + __name__)
+
 def get_all_repositories_and_protocols(paper, user):
     repositories = Repository.objects.all()
     protocols = []
@@ -59,7 +62,7 @@ def get_metadata_form(request):
     repo = get_object_or_404(Repository, pk=request.GET.get('repository'))
     protocol = repo.protocol_for_deposit(paper, request.user)
     if protocol is None:
-        print("no protocol")
+        logger.warning("No protocol")
         return {'status': 'repoNotAvailable',
                 'message': _('This repository is not available for this paper.')}
 
@@ -85,7 +88,7 @@ def start_view(request, pk):
         selected_protocol = repositories_protocol.get(selected_repository.id)
 
     # Try to get the last one used by this user
-    print(userprefs.last_repository)
+    logger.info(userprefs.last_repository)
     if selected_protocol is None and userprefs.last_repository:
         selected_repository = userprefs.last_repository
         selected_protocol = repositories_protocol.get(selected_repository.id)

--- a/dissemin/celery.py
+++ b/dissemin/celery.py
@@ -4,6 +4,7 @@
 
 
 import os
+import logging
 
 from celery import Celery
 from django.conf import settings
@@ -18,7 +19,8 @@ app = Celery('dissemin')
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
+logger = logging.getLogger('dissemin.' + __name__)
 
 @app.task(bind=True)
 def debug_task(self):
-    print('Request: {0!r}'.format(self.request))
+    logger.debug('Request: {0!r}'.format(self.request))

--- a/dissemin/fasttestrunner.py
+++ b/dissemin/fasttestrunner.py
@@ -3,6 +3,8 @@
 
 # taken from https://www.caktusgroup.com/blog/2013/10/02/skipping-test-db-creation/
 
+import logging
+
 from django.test import TransactionTestCase
 try:
     from django.test.runner import DiscoverRunner as BaseRunner
@@ -12,6 +14,7 @@ except ImportError:
 
 from mock import patch
 
+logger = logging.getLogger('dissemin.' + __name__)
 
 class NoDatabaseMixin(object):
     """
@@ -36,7 +39,7 @@ class NoDatabaseMixin(object):
         if self._needs_db:
             return super(NoDatabaseMixin, self).setup_databases(*args, **kwargs)
         if self.verbosity >= 1:
-            print('No DB tests detected. Skipping Test DB creation...')
+            logger.info('No DB tests detected. Skipping Test DB creation...')
         self._db_patch = patch('django.db.backends.utils.CursorWrapper')
         self._db_mock = self._db_patch.start()
         self._db_mock.side_effect = RuntimeError('No testing the database!')

--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -391,14 +391,14 @@ LOGGING = {
 }
 
 # If sentry is set, we send all important logs to sentry.
-SENTRY_DSN = True
+
 if SENTRY_DSN:
-    LOGGING['handlers'] = {**{
+    LOGGING['handlers'].update({
         'sentry': {
             'level': 'WARNING',
             'class': 'sentry_sdk.integrations.logging.EventHandler',
             }
-        }, ** LOGGING['handlers']}
+        })
 
     LOGGING['loggers']['']['handlers'] += ['sentry']
     LOGGING['loggers']['dissemin']['handlers'] += ['sentry']

--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -356,3 +356,40 @@ SETTINGS_EXPORT = [
     'SENTRY_DSN',
 ]
 
+# Logging is very important thing. Here we define some standards. We use Django logging system, so there it is easy to custimze your logging preferences.
+# To switch for 'console' to level 'DEBUG' please use prod.py resp. dev.py
+# To get a logger use logger = logging.getLogger('dissemin.' + __name__) to make sure that it is catched by the dissemin logger.
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'console': {
+            'format': '%(asctime)s %(levelname)s %(name)s:%(lineno)s  %(message)s',
+            'datefmt': '%Y-%m-%d %H:%M:%S',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'console',
+        },
+        'sentry': {
+            'level': 'WARNING',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+        },
+    },
+    'loggers': {
+    # root logger, includes also third party packages. To omit them them, put in 'django' to get just django related logging
+        '': {
+            'level': 'WARNING',
+            'handlers': ['console', 'sentry'],
+        },
+    # dissemin logger
+        'dissemin' : {
+            'level': None,
+            'handlers': ['console', 'sentry'],
+            'propagate': False,
+        },
+    },
+}

--- a/dissemin/settings/common.py
+++ b/dissemin/settings/common.py
@@ -374,22 +374,31 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'console',
         },
-        'sentry': {
-            'level': 'WARNING',
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
-        },
     },
     'loggers': {
     # root logger, includes also third party packages. To omit them them, put in 'django' to get just django related logging
         '': {
             'level': 'WARNING',
-            'handlers': ['console', 'sentry'],
+            'handlers': ['console'],
         },
     # dissemin logger
         'dissemin' : {
             'level': None,
-            'handlers': ['console', 'sentry'],
+            'handlers': ['console'],
             'propagate': False,
         },
     },
 }
+
+# If sentry is set, we send all important logs to sentry.
+SENTRY_DSN = True
+if SENTRY_DSN:
+    LOGGING['handlers'] = {**{
+        'sentry': {
+            'level': 'WARNING',
+            'class': 'sentry_sdk.integrations.logging.EventHandler',
+            }
+        }, ** LOGGING['handlers']}
+
+    LOGGING['loggers']['']['handlers'] += ['sentry']
+    LOGGING['loggers']['dissemin']['handlers'] += ['sentry']

--- a/dissemin/settings/dev.py
+++ b/dissemin/settings/dev.py
@@ -9,6 +9,8 @@ from .common import *
 DEBUG = True
 DEBUG_TOOLBAR_CONFIG = {'SHOW_TOOLBAR_CALLBACK': lambda r: True}
 
+LOGGING['loggers']['dissemin']['level'] = DEBUG
+
 # They are the domains under which your dissemin instance should
 # be reachable. Leave empty if you run on localhost.
 ALLOWED_HOSTS = []

--- a/dissemin/settings/prod.py
+++ b/dissemin/settings/prod.py
@@ -11,6 +11,8 @@ from .common import *
 
 DEBUG = False
 
+LOGGING['loggers']['dissemin']['level'] = DEBUG
+
 # They are the domains under which your dissemin instance should
 # be reachable
 ALLOWED_HOSTS = ['dissem.in']

--- a/papers/baremodels.py
+++ b/papers/baremodels.py
@@ -28,6 +28,7 @@ without name ambiguity resolution.
 
 
 import hashlib
+import logging
 import re
 from urllib.parse import quote  # for the Google Scholar and CORE link
 from urllib.parse import urlencode
@@ -49,6 +50,8 @@ from papers.utils import validate_orcid
 from publishers.models import DummyPublisher
 from publishers.models import OA_STATUS_CHOICES
 from publishers.models import OA_STATUS_PREFERENCE
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 PAPER_TYPE_CHOICES = [
    ('journal-article', _('Journal article')),
@@ -490,7 +493,7 @@ class BarePaper(BareObject):
         fp = create_paper_plain_fingerprint(
             self.title, self.bare_author_names(), self.year)
         if verbose:
-            print(fp)
+            logger.debug(fp)
         return fp
 
     def new_fingerprint(self, verbose=False):

--- a/papers/bibtex.py
+++ b/papers/bibtex.py
@@ -20,12 +20,15 @@
 
 
 import re
+import logging
 
 import bibtexparser
 import bibtexparser.customization
 
 from bibtexparser.bparser import BibTexParser
 from papers.name import parse_comma_name
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 # There should not be "et al" in Bibtex but we encounter it from time to time
 ET_AL_RE = re.compile(r'( and )?\s*et\s+al\.?\s*$', re.IGNORECASE | re.UNICODE)
@@ -75,11 +78,6 @@ def parse_bibtex(bibtex):
     if len(db.entries) == 0:
         raise ValueError('No bibtex item was parsed.')
     if len(db.entries) > 1:
-        print(
-            (
-                "Warning: %d Bibtex items in parse_bibtex, "
-                "defaulting to the first one"
-            ) % len(db.entries)
-        )
+        logger.warning("%d bibtex items, defaulting to first one" % len(db.entries)) 
 
     return db.entries[0]

--- a/papers/models.py
+++ b/papers/models.py
@@ -49,6 +49,7 @@ from datetime import timedelta
 import re
 import haystack
 import pytz
+import logging
 from statistics.models import AccessStatistics
 from statistics.models import combined_status_for_instance
 from statistics.models import STATUS_CHOICES_HELPTEXT
@@ -94,6 +95,8 @@ from publishers.models import Journal
 from publishers.models import Publisher
 from solo.models import SingletonModel
 from search import SearchQuerySet
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 UPLOAD_TYPE_CHOICES = [
    ('preprint', _('Preprint')),
@@ -449,7 +452,7 @@ class Researcher(models.Model):
 
     def update_stats(self):
         """Update the access statistics for the papers authored by this researcher"""
-        print("Researcher.update_stats should not be used anymore")
+        logger.info("Researcher.update_stats should not be used anymore")
         #if not self.stats:
         #    self.stats = AccessStatistics.objects.create()
         #    self.save()

--- a/papers/name.py
+++ b/papers/name.py
@@ -21,10 +21,13 @@
 
 
 import re
+import logging
 
 import name_tools
 from papers.utils import iunaccent
 from papers.utils import remove_diacritics
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 # Name managemement: heuristics to separate a name into (first,last)
 comma_re = re.compile(r',+')
@@ -91,8 +94,7 @@ def rebuild_name(name_words, separators):
         if idx < len(separators):
             output += separators[idx]
         elif idx < len(name_words)-1:
-            print("WARNING: incorrect name splitting for '%s'" %
-                  str(name_words))
+            logger.warning("Incorrect name splitting for '%s'" % str(name_words))
             output += ' '
     return output
 

--- a/papers/orcid.py
+++ b/papers/orcid.py
@@ -19,8 +19,9 @@
 #
 
 
-
+import logging
 import requests
+
 
 from django.conf import settings
 from django.utils.functional import cached_property
@@ -35,6 +36,8 @@ from papers.utils import try_date
 from papers.baremodels import BareName
 from papers.bibtex import parse_bibtex
 from papers.doi import to_doi
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 orcid_type_to_pubtype = {
         'book': 'book',
@@ -380,7 +383,7 @@ class OrcidWork(object):
         pubdate = try_date(year, month, day) or try_date(
             year, month, 1) or try_date(year, 1, 1)
         if pubdate is None:
-            print("Invalid publication date in ORCID publication, skipping")
+            logger.info("Invalid publication date in ORCID publication, skipping")
             raise SkippedPaper("INVALID_PUB_DATE")
         else:
             return pubdate

--- a/publishers/romeo.py
+++ b/publishers/romeo.py
@@ -23,6 +23,7 @@
 from io import BytesIO
 
 import dateutil.parser
+import logging
 import re
 import requests.exceptions
 
@@ -40,6 +41,8 @@ from publishers.models import Publisher
 from publishers.models import PublisherCondition
 from publishers.models import PublisherCopyrightLink
 from publishers.models import PublisherRestrictionDetail
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 class RomeoAPI(object):
 
@@ -112,8 +115,7 @@ class RomeoAPI(object):
         if not journals:
             return None
         elif len(journals) > 1:
-            print("Warning, "+str(len(journals))+" journals match the RoMEO request, " +
-                  "defaulting to the first one")
+            logger.warning("%d journals match the RoMEO request, defaulting to the first one" % len(journals))
             # TODO different behaviour: get the ISSN and try again.
         journal = journals[0]
 
@@ -122,8 +124,7 @@ class RomeoAPI(object):
             raise MetadataSourceException('RoMEO returned a journal without title.\n' +
                                           'Terms were: '+str(terms))
         if len(names) > 1:
-            print("Warning, "+str(len(names))+" names provided for one journal, " +
-                  "defaulting to the first one")
+            logger.warning("%d names provided for one journal, defaulting to the first one" % len(names))
         name = kill_html(names[0].text)
 
         issn = None
@@ -203,8 +204,8 @@ class RomeoAPI(object):
         for publisher in publishers:
             try:
                 self.get_or_create_publisher(publisher)
-            except MetadataSourceException as exception:
-                print(exception)
+            except MetadataSourceException:
+                logger.exception()
 
     def fetch_all_journals(self):
         """

--- a/upload/forms.py
+++ b/upload/forms.py
@@ -20,10 +20,14 @@
 
 
 
+import logging
+
 from dissemin.settings import DEPOSIT_MAX_FILE_SIZE
 from django import forms
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import ugettext as _
+
+logger = logging.getLogger('dissemin.' + __name__)
 
 invalid_content_type_message = _(
     'Invalid file format: only PDF files are accepted.')
@@ -34,7 +38,7 @@ class AjaxUploadForm(forms.Form):
 
     def clean_upl(self):
         content = self.cleaned_data['upl']
-        print(content.content_type)
+        logger.info(content.content_type)
         if content.size > DEPOSIT_MAX_FILE_SIZE:
             raise forms.ValidationError(_('File too large (%(size)s). Maximum size is %(maxsize)s.') %
                                         {'size': filesizeformat(content._size),


### PR DESCRIPTION
Tackling Issue #603. There is a logger for console, which is send in production to apache and everything that is a warning or higher should be sent to Sentry.

@Phyks Since you recently worked Sentry support, could you do that for the logs to? I Think that in `dissemin/settings/common.py` should be everything ready according to this documentation: 
https://docs.sentry.io/platforms/python/logging/#handler-classes
https://forum.sentry.io/t/sentry-python-dictconfig/5065/3

Also, not all print statements where removed, those from the tests, migrations and settings are still remaining:

```bash
$ grep -rn -e "\(\$\| \)print(" ./ --include=*py
./deposit/tests/test_protocol.py:131:            print(form.errors)
./deposit/tests/test_protocol.py:149:            print(self.proto._logs)
./dissemin/settings/common.py:60:        print('Sentry module is not available although a Sentry DSN was set. '
./papers/migrations/0036_paper_temp.py:19:        print(lastpk)
./papers/migrations/0004_strip_latex.py:19:                print('"%s" -> "%s"' % (paper.title,new_title))
./papers/tests/test_ajax.py:52:            print("Invalid status code %d, response was:\n%s" %
./papers/tests/test_pages.py:64:            print(resp.content)
./papers/tests/test_pages.py:65:            print("HTML validation error: "+str(e))
./papers/tests/test_pages.py:211:                print(p)
./papers/tests/test_bibtex.py:124:        print(parse_bibtex(bibtex)['author'][0][0])
./papers/tests/test_orcid.py:45:            print(e)
./papers/tests/test_orcid.py:48:            print(r.json())
./upload/tests/test_views.py:102:            print("Invalid status code %d, response was:\n%s" %
./upload/tests/test_views.py:109:            print(("Invalid status code %d, response was:\n%s" %
```

while the rest is replaced with logging statements.

No new logging statements where added.