### PR TITLE
Move ES6 syntax to jQuery syntax to avoid issues with old browsers

### DIFF
--- a/papers/static/papers/refresh.js
+++ b/papers/static/papers/refresh.js
@@ -19,11 +19,11 @@ function init_paper_module (config) {
   function call_api(url, user_config) {
     var csrftoken = getCookie('csrftoken');
     var config = user_config || {}
-    return fetch(url, Object.assign(
+    return fetch(url, $.extend(
       {},
       config,
       {
-        headers: Object.assign({}, config.headers || {}, {
+        headers: $.extend({}, config.headers || {}, {
           'X-CSRFToken': csrftoken,
           'Content-Type': 'application/json'
         }),


### PR DESCRIPTION
`Object.assign` is only defined in ES6, therefore not available in old browsers such as iOS 8, see https://sentry.io/organizations/dissemin/issues/954240591/?project=189330&query=is%3Aunresolved&statsPeriod=14d&utc=false.

jQuery has a `$.extend` (https://api.jquery.com/jQuery.extend/) which should do the trick everywhere.