### PR TITLE
Shorten Author List in Page Title

### DIFF
--- a/papers/templates/papers/paper.html
+++ b/papers/templates/papers/paper.html
@@ -20,7 +20,7 @@
     {% endif %}
 {% endblock %}
 
-{% block headTitle %}{{ paper.title }} - {{ paper.authors | join:', ' }}{% endblock %}
+{% block headTitle %}{{ paper.title }} - {{ paper.interesting_authors | join:', ' }}{% endblock %}
 
 {% block bodyTitle %}
 <h1 id="paperTitle" data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" data-pk="{{ paper.pk }}">


### PR DESCRIPTION
One (very) extreme example is 

https://dissem.in/p/3994958/combined-measurement-of-the-higgs-boson-mass-in-pp-collisions-at-root-s7-and-8-tev-with-the-atlas-and-cms-experiments

But more than 15 authors might happen from time to time, so a cutdown in the html title is fine, since it's you used as tab name.