### PR TITLE
Make Crossref import more robust

### DIFF
--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,0 +1,19 @@
+
+
+from backend.utils import report_speed
+from backend.utils import with_speed_report
+from time import sleep
+from datetime import timedelta
+
+def test_report_speed():
+    assert list(with_speed_report(range(10))) == list(range(10))
+    assert list(with_speed_report([])) == []
+    
+    @report_speed(name='my_generator', report_delay=timedelta(seconds=0.1))
+    def second_generator(limit):
+        for elem in range(limit):
+            sleep(0.01)
+            yield elem
+    
+    assert list(second_generator(20)) == list(range(20))
+    

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -25,6 +25,8 @@ from time import sleep
 import logging
 import requests
 import requests.exceptions
+from datetime import datetime
+from datetime import timedelta
 
 from dissemin.settings import redis_client
 from memoize import memoize
@@ -63,7 +65,18 @@ class run_only_once(object):
 
 # Open an URL with retries
 
-def urlopen_retry(url, **kwargs):  # data, timeout, retries, delay, backoff):
+def request_retry(url, **kwargs):
+    """
+    Retries a request, with throttling and exponential back-off.
+    
+    :param url: the URL to fetch
+    :param data: the GET parameters
+    :param headers: the HTTP headers
+    :param timeout: the number of seconds to wait before declaring that an individual request timed out (default 10)
+    :param retries: the number of times to retry a query (default 3)
+    :param delay: the minimum delay between requests (default 5)
+    :param backoff: the multiple used when raising the delay after an unsuccessful query (default 2)
+    """
     data = kwargs.get('data', None)
     timeout = kwargs.get('timeout', 10)
     retries = kwargs.get('retries', 3)
@@ -76,7 +89,7 @@ def urlopen_retry(url, **kwargs):  # data, timeout, retries, delay, backoff):
                          timeout=timeout,
                          headers=headers,
                          allow_redirects=True)
-        return r.text
+        return r
     except requests.exceptions.Timeout as e:
         if retries <= 0:
             raise MetadataSourceException('Timeout: '+str(e))
@@ -95,7 +108,43 @@ def urlopen_retry(url, **kwargs):  # data, timeout, retries, delay, backoff):
                          delay=delay*backoff,
                          backoff=backoff)
 
+def urlopen_retry(url, **kwargs):
+    return request_retry(url, **kwargs).text
 
 @memoize(timeout=86400)  # 1 day
 def cached_urlopen_retry(*args, **kwargs):
     return urlopen_retry(*args, **kwargs)
+
+def with_speed_report(generator, name=None, report_delay=timedelta(seconds=10)):
+    """
+    Periodically reports the speed at which we are enumerating the items
+    of a generator.
+    
+    :param name: a name to use in the reports (eg "papers from Crossref API")
+    :param report_delay: print a report every so often
+    """
+    if name is None:
+        name = getattr(generator, "__name__", "")
+    last_report = datetime.now()
+    nb_records_since_last_report = 0
+    for idx, record in enumerate(generator):
+        yield record
+        nb_records_since_last_report += 1
+        now = datetime.now()
+        if last_report + report_delay < now:
+            rate = nb_records_since_last_report / float((now - last_report).total_seconds())
+            logger.info('{}: {}, {} records/sec'.format(name, idx, rate))
+            last_report = now
+
+def report_speed(name=None, report_delay=timedelta(seconds=10)):
+    """
+    Decorator for a function that returns a generator, see with_speed_report
+    """
+    def decorator(func):
+        logging_name = name
+        if logging_name is None:
+            logging_name = getattr(func, "__name__", "")
+        def wrapped_generator(*args, **kwargs):
+            return with_speed_report(func(*args, **kwargs), name=logging_name, report_delay=report_delay)
+        return wrapped_generator
+    return decorator


### PR DESCRIPTION
This refactors a few things to add rate reporting to crossref and make it robust to 500 errors. A generic decorator to add rate reporting to a generator is introduced.