### PR TITLE
Index ORCID ids in Paper objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 3.4
   - 3.5
   - 3.6
 

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -80,7 +80,7 @@ def fetch_everything_for_researcher(pk):
     update_researcher_task(r, 'orcid')
 
     try:
-        orcid_paper_source.link_existing_papers()
+        orcid_paper_source.link_existing_papers(r)
         orcid_paper_source.fetch_and_save(r)
         update_researcher_task(r, None)
 

--- a/papers/forms.py
+++ b/papers/forms.py
@@ -148,12 +148,8 @@ class PaperForm(SearchForm):
             # these as orcid ids and do the filtering
             orcid_ids = [x for x in name.split(' ') if validate_orcid(x)]
             for orcid_id in orcid_ids:
-                try:
-                    researcher = Researcher.objects.get(orcid=orcid_id)
-                    self.filter(researchers=researcher.id)
-                except Researcher.DoesNotExist:
-                    pass
-                continue
+                self.filter(orcids=orcid_id)
+
             # Rebuild a full name excluding the ORCID id terms
             name = ' '.join([x for x in name.split(' ') if x not in orcid_ids])
 

--- a/papers/models.py
+++ b/papers/models.py
@@ -1163,6 +1163,8 @@ class Paper(models.Model, BarePaper):
                 author.affiliation = new_authors[new_idx].affiliation
             if new_idx is not None and new_authors[new_idx].orcid:
                 author.orcid = new_authors[new_idx].orcid
+            if new_idx is not None and new_authors[new_idx].researcher_id:
+                author.researcher_id = new_authors[new_idx].researcher_id
 
             unified_authors.append(author.serialize())
         self.authors_list = unified_authors

--- a/papers/search_indexes.py
+++ b/papers/search_indexes.py
@@ -63,7 +63,7 @@ class PaperIndex(indexes.SearchIndex, indexes.Indexable):
         return obj.researcher_ids
 
     def prepare_orcids(self, obj):
-        return [orcid for orcid in obj.orcids if orcid]
+        return [orcid for orcid in obj.orcids() if orcid]
 
     def prepare_institutions(self, obj):
         return [x for x in [r.institution_id

--- a/papers/search_indexes.py
+++ b/papers/search_indexes.py
@@ -23,6 +23,9 @@ class PaperIndex(indexes.SearchIndex, indexes.Indexable):
     #: IDs of researchers
     researchers = IntegerMultiValueField()
 
+    #: ORCIDs of researchers
+    orcids = indexes.MultiValueField()
+
     #: IDs of institutions of researchers
     institutions = IntegerMultiValueField()
 
@@ -58,6 +61,9 @@ class PaperIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_researchers(self, obj):
         return obj.researcher_ids
+
+    def prepare_orcids(self, obj):
+        return [orcid for orcid in obj.orcids if orcid]
 
     def prepare_institutions(self, obj):
         return [x for x in [r.institution_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyPDF2
 bibtexparser>=1.1.0
 redis<3
 cryptography
-django>=1.11.20,<2.3.0
+django>=2.2.0,<2.3.0
 django-allauth
 -e git+https://github.com/dissemin/django-autocomplete-light.git@78b587a481ff29bc62145fe04af7e0608b026675#egg=django-autocomplete-light
 django-bootstrap-pagination


### PR DESCRIPTION
This changes the search index so that ORCID ids are directly indexed there.

We currently only index researcher ids (we don't have researchers for every ORCID profile, hence the discrepancy).

Tests are still needed and `link_existing_papers` needs to be hooked to the rest of the code for #659.