### PR TITLE
[requires.io] dependency update on master branch

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 django-debug-toolbar
-pytest==4.4.0
+pytest==4.4.1
 pytest-django
 sphinx
 coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
 django-debug-toolbar
+html5validator
 pytest==4.4.1
 pytest-django
 sphinx
 coverage
 pyflakes
+pytidylib

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 django-debug-toolbar
 html5validator
-pytest==4.4.1
+pytest==4.4.2
 pytest-django
 sphinx
 coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 django-debug-toolbar
-pytest==4.1.1
+pytest==4.4.0
 pytest-django
 sphinx
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,8 @@ django-ratelimit
 django-widget-tweaks
 django-debug-toolbar
 djangorestframework
-elasticsearch==6.3.1
-html5lib==0.999999999
+elasticsearch==7.0.0
+html5lib==1.0.1
 httplib2
 jsonfield
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ wand
 sentry-sdk
 python-dateutil # for haystack, as explained here:
 #http://django-haystack.readthedocs.io/en/v2.4.1/management_commands.html
+dealer

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ django-widget-tweaks
 django-debug-toolbar
 djangorestframework
 elasticsearch==7.0.0
-html5lib==1.0.1
 httplib2
 jsonfield
 lxml


### PR DESCRIPTION
- [ ] Elasticsearch update seems incompatible with latest Django Haystack version.