### PR TITLE
Emphasize missing papers faq. Fix #529.

### DIFF
--- a/papers/static/style/style.css
+++ b/papers/static/style/style.css
@@ -272,9 +272,12 @@ li
 .notFound {
     text-align: center;
     font-size: 1.5em;
-    margin-top: 40px;
     margin-bottom: 30px;
     color: #999;
+}
+
+.notFoundWithMargin {
+    margin-top: 40px;
 }
 
 .ulContainer

--- a/papers/templates/papers/paperList.html
+++ b/papers/templates/papers/paperList.html
@@ -27,16 +27,24 @@
     <p class="notFound">{% trans "No paper found." %}</p>
     {% endif %}
  {% endfor %}
- {% if page_obj.paginator.num_pages > 1 %}
- <div class="searchPages">{% bootstrap_paginate page_obj range=10 %}</div>
- {% elif researcher %}
-    {% with researcher.matching_papers_url as matching_papers_url %}
-    <p class="notFound">{% blocktrans trimmed %}
-	Missing publications?
-        <a href="{{ matching_papers_url }}">
-	Search for publications with a matching author name
-	</a>
-	{% endblocktrans %}
+
+{% if page_obj.paginator.num_pages > 1 %}
+    <div class="searchPages">{% bootstrap_paginate page_obj range=10 %}</div>
+{% endif %}
+
+{% if researcher %}
+    <p class="notFound notFoundWithMargin">
+        {% with researcher.matching_papers_url as matching_papers_url %}
+            {% blocktrans trimmed %}
+                Missing publications? <a href="{{ matching_papers_url }}">Search for publications with a matching author name</a>
+            {% endblocktrans %}
+        {% endwith %}
     </p>
-    {% endwith %}
- {% endif %}
+{% else %}
+    <p class="notFound">
+        {% url 'faq' as faq_url %}
+        {% blocktrans trimmed %}
+            Missing publications? <a href="{{ faq_url }}#missing-paper">Read more about our data sources.</a>
+        {% endblocktrans %}
+    </p>
+{% endif %}

--- a/templates/dissemin/faq.html
+++ b/templates/dissemin/faq.html
@@ -51,7 +51,7 @@
         <h2 id="open-access">{% trans "What is Open Access?" %}</h2>
         <p>
         {% blocktrans trimmed %}
-        In a nutshell, the Open Access movement promotes free access to the scientific literature. For a 
+        In a nutshell, the Open Access movement promotes free access to the scientific literature. For a
         more in-depth introduction, we recommend
         <a href="http://www.phdcomics.com/comics.php?f=1533">this video in English</a>
         and
@@ -155,7 +155,7 @@
               </li>
 	      <li>
         {% blocktrans trimmed %}
-                <strong><a href="https://osf.io/preprints/">OSF preprints</a></strong>, 
+                <strong><a href="https://osf.io/preprints/">OSF preprints</a></strong>,
 		a preprint server run by the <a href="https://cos.io/">Center for Open Science</a> on
 		top of their <a href="https://osf.io/">Open Science Framework</a>.
         {% endblocktrans %}
@@ -334,7 +334,9 @@
             Please first check whether the paper is available in one of
             <a href="{{ sources_url }}">our sources</a>. If it is not, Dissemin
             cannot harvest it, and you should report the problem to the source
-            where it should appear.
+            where it should appear. Note that it can take up to a couple of
+            months for our primary sources to discover your latest papers and
+            for Dissemin to harvest it.
             {% endblocktrans %}
             </p>
             <p>
@@ -414,9 +416,9 @@
             covered by BASE.
             Hence, if you are a user of a repository and would like it to be supported
             by Dissemin, please contact the repository administrator and suggest
-            them to implement OAI-PMH support and to 
+            them to implement OAI-PMH support and to
             <a href="https://www.base-search.net/about/en/suggest.php">register</a>
-            their repository in BASE. 
+            their repository in BASE.
             {% endblocktrans %}
        </p>
        <p>
@@ -500,7 +502,7 @@
         </p>
 
         <h2 id="orcid-update">{% trans "My ORCID details on Dissemin are outdated." %}</h2>
-        
+
         <p>
             {% blocktrans trimmed %}
             If you change some details in your ORCID profile (name, homepage,


### PR DESCRIPTION
Here is a proposal to fix #529.

<img width="1193" alt="Capture d’écran 2019-04-12 à 14 55 46" src="https://user-images.githubusercontent.com/3856586/56038800-13e4fc80-5d33-11e9-9746-ef144fb28aa2.png">


While researcher page remain untouched

<img width="1284" alt="Capture d’écran 2019-04-12 à 14 56 45" src="https://user-images.githubusercontent.com/3856586/56038851-3545e880-5d33-11e9-90a1-133ef8a8677c.png">


Actually, there seemed to be a bug in the previous researcher code, preventing the "not found" text to be shown when there were multiple pages. Not sure whether this was on purpose?