### PR TITLE
Add an example Apache2 vhost

### DIFF
--- a/doc/sphinx/deploying.rst
+++ b/doc/sphinx/deploying.rst
@@ -59,63 +59,8 @@ to load MathJax from. In the example below, this would be
 Apache with WSGI
 ----------------
 
-Here is a sample VirtualHost, assuming that the root of the Dissemin source code is at ``/home/dissemin`` and you use ``python3.6``.::
+A sample VirtualHost, assuming that the root of the Dissemin source code is at ``/home/dissemin/prod`` and you use a ``python3.5`` virtualenv is available in the `Dissemin Git repository <https://github.com/dissemin/dissemin/blob/master/provisioning/apache2-vhost.conf` (under ``provisioning/apache2-vhost.conf``).
 
-    <VirtualHost *:80>
-            ServerAdmin webmaster@localhost
-            ServerName dissemin.myuni.edu
-
-            ### STATIC FILES ###
-
-            # Instructions for robots
-            Alias /robots.txt /home/dissemin/www/static/robots.txt
-            <Location /robots.txt>
-            Require all granted
-            </Location>
-            # Thumbnails of PDF files uploaded by users
-            Alias /media/thumbnails/ /home/dissemin/media/thumbnails/
-            <Directory /home/dissemin/media/thumbnails>
-            Require all granted
-            </Directory>
-            # Logos of the repositories configured on your instance
-            Alias /media/repository_logos/ /home/dissemin/media/repository_logos/
-            <Directory /home/dissemin/media/repository_logos>
-            Require all granted
-            </Directory>
-            # Generic static files (CSS, JS, images)
-            Alias /static/ /home/dissemin/www/static/
-            <Directory /home/dissemin/www/static>
-            Require all granted
-            </Directory>
-
-            ### WSGI connection ###
-
-            # Path to the WSGI application for the website
-            WSGIScriptAlias / /home/dissemin/dissemin/wsgi.py
-            # Python path for the application
-            WSGIDaemonProcess dissemin.myuni.edu python-path=/home/dissemin:/home/dissemin/.virtualenv/lib/python3.6/site-packages
-
-            WSGIProcessGroup dissemin.myuni.edu
-
-            <Directory /home/dissemin/dissemin>
-            <Files wsgi.py>
-            Require all granted
-            </Files>
-            </Directory>
-
-            ### Error handling ###
-            ErrorDocument 500 /500-error
-            ErrorDocument 404 /404-error
-
-            ### Log settings ###
-            ErrorLog ${APACHE_LOG_DIR}/django-dissemin-myuni.log
-
-            # Possible values include: debug, info, notice, warn, error, crit,
-            # alert, emerg.
-            LogLevel debug
-
-            CustomLog ${APACHE_LOG_DIR}/access-dissemin-myuni.log combined
-    </VirtualHost>
 
 You should only have to change the path to the application and the domain name of the service.
 

--- a/provisioning/apache2-vhost.conf
+++ b/provisioning/apache2-vhost.conf
@@ -6,6 +6,7 @@
     Redirect permanent / https://dissem.in/
 </VirtualHost>
 
+SSLStaplingCache        shmcb:/var/run/ocsp(128000)
 <VirtualHost *:443>
     ServerAdmin webmaster@localhost
     ServerName dissem.in
@@ -30,7 +31,6 @@
     SSLUseStapling          on
     SSLStaplingResponderTimeout 5
     SSLStaplingReturnResponderErrors off
-    SSLStaplingCache        shmcb:/var/run/ocsp(128000)
 
     # Security headers
     # ================

--- a/provisioning/apache2-vhost.conf
+++ b/provisioning/apache2-vhost.conf
@@ -2,17 +2,6 @@
     # Upgrade insecure connections to HTTPS.
     ServerAdmin webmaster@localhost
     ServerName dissem.in
-    ServerAlias prod.dissem.in www.dissem.in
-
-    Redirect permanent / https://dissem.in/
-</VirtualHost>
-
-<VirtualHost *:443>
-    # Create a VirtualHost to redirect any alternative (legacy) domain
-    # to "dissem.in" in a permanent way.
-    ServerAdmin webmaster@localhost
-    ServerName www.dissem.in
-    ServerAlias prod.dissem.in
 
     Redirect permanent / https://dissem.in/
 </VirtualHost>

--- a/provisioning/apache2-vhost.conf
+++ b/provisioning/apache2-vhost.conf
@@ -1,0 +1,119 @@
+<VirtualHost *:80>
+    # Upgrade insecure connections to HTTPS.
+    ServerAdmin webmaster@localhost
+    ServerName dissem.in
+    ServerAlias prod.dissem.in www.dissem.in
+
+    Redirect permanent / https://dissem.in/
+</VirtualHost>
+
+<VirtualHost *:443>
+    # Create a VirtualHost to redirect any alternative (legacy) domain
+    # to "dissem.in" in a permanent way.
+    ServerAdmin webmaster@localhost
+    ServerName www.dissem.in
+    ServerAlias prod.dissem.in
+
+    Redirect permanent / https://dissem.in/
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    ServerName dissem.in
+
+    # SSL configuration
+    # =================
+    SSLEngine on
+    SSLCertificateFile    /etc/letsencrypt/live/dissem.in/cert.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/dissem.in/privkey.pem
+    SSLCertificateChainFile /etc/letsencrypt/live/dissem.in/fullchain.pem
+    # Use HSTS
+    # TODO: Include subdomains? Preload?
+    Header always set Strict-Transport-Security "max-age=15768000"
+    # Ciphers configuration from Mozilla
+    # https://mozilla.github.io/server-side-tls/ssl-config-generator/
+    SSLProtocol             all -SSLv3
+    SSLCipherSuite          ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
+    SSLHonorCipherOrder     on
+    SSLCompression          off
+    SSLSessionTickets       off
+    # OCSP Stapling, only in httpd 2.3.3 and later
+    SSLUseStapling          on
+    SSLStaplingResponderTimeout 5
+    SSLStaplingReturnResponderErrors off
+    SSLStaplingCache        shmcb:/var/run/ocsp(128000)
+
+    # Security headers
+    # ================
+    # TODO: Content Security Policy?
+    # XSS filter enabled and prevented rendering the page if attack detected
+    Header set X-XSS-Protection "1; mode=block"
+    # Prevent browsers from guessing MIME type
+    Header set X-Content-Type-Options nosniff
+
+    # CORS for the API
+    # ================
+    <Location /api>
+        Header set Access-Control-Allow-Origin "*"
+    </Location>
+
+    # Static assets configuration
+    # ===========================
+    # Note that Apache2 requires a Location block for every Alias directive.
+    Alias /robots.txt /home/dissemin/prod/www/robots.txt
+    Alias /favicon.ico /home/dissemin/prod/www/favicon/favicon.ico
+    Alias /favicon/ /home/dissemin/prod/www/favicon/
+    Alias /static/ /home/dissemin/prod/www/
+    Alias /media/thumbnails/ /dissemin/media/thumbnails/
+    Alias /media/repository_logos/ /dissemin/media/repository_logos/
+    # Enable GZIP compression of static files
+    <Location /robots.txt>
+	Require all granted
+    </Location>
+    <Location /favicon.ico>
+        SetOutputFilter DEFLATE
+        Require all granted
+    </Location>
+    <Location /favicon>
+        SetOutputFilter DEFLATE
+        Require all granted
+    </Location>
+    <Location /media>
+        SetOutputFilter DEFLATE
+        Require all granted
+    </Location>
+    <Location /static>
+        SetOutputFilter DEFLATE
+        Require all granted
+    </Location>
+    # TODO: Add Cache-Control headers
+
+    # Error pages
+    # ===========
+    ErrorDocument 500 /500-error
+    ErrorDocument 404 /404-error
+
+    # Set up WSGI for the main app
+    # ============================
+    WSGIScriptAlias / /home/dissemin/prod/dissemin/wsgi.py
+    WSGIDaemonProcess prod.dissem.in python-path=/home/dissemin/prod:/home/dissemin/prod/.venv/lib/python3.5/site-packages user=dissemin processes=4
+    WSGIProcessGroup prod.dissem.in
+    <Directory /home/dissemin/prod/dissemin/>
+        <Files wsgi.py>
+            Require all granted
+        </Files>
+    </Directory>
+
+    # Handle maintenance page
+    # =======================
+    RewriteEngine On
+    RewriteCond /home/dissemin/prod/www/maintenance.html -f
+    RewriteCond %{REQUEST_FILENAME} !/maintenance.html
+    RewriteRule ^.*$    /home/dissemin/prod/www/maintenance.html [L]
+
+    # Logging
+    # =======
+    LogLevel info
+    ErrorLog ${APACHE_LOG_DIR}/django-dissemin-prod.log
+    CustomLog ${APACHE_LOG_DIR}/access-dissemin-prod.log combined
+</VirtualHost>


### PR DESCRIPTION
This is an attempt at fixing https://github.com/dissemin/dissemin/issues/687. This would also provide users with a typical vhost to start from, to help them get starting hosting a Dissemin instance.

So far,
- We don't use any security HTTP headers (content security policy etc) on the production instance.
- We have a [B grade](https://www.ssllabs.com/ssltest/analyze.html?d=dissem.in) SSL score, part of the issues are easily fixable (the rest being difficult without dropping support for older browsers)
- We lack gzip and caching strategy for the static assets, see #687.
- We don't have CORS headers for the API, therefore preventing from using it from within the browser.

Note that this is a work in progress and currently untested :) Definitely not ready for a merge yet.

Left to do:

- [ ] We should have `Content Security Policy` headers to state where the resources can be fetched from.
- [ ] We should add <s>gzip /</s> caching for the static assets. Gzip is done, caching policy should be kept for the future I think.

These are left as `TODOs` in the code and I think it will be better to handle them separately in a future PR (when refactoring and updating the JS dependencies for instance).