### PR TITLE
Use HTTPS in HAL.

### DIFF
--- a/deposit/hal/protocol.py
+++ b/deposit/hal/protocol.py
@@ -168,7 +168,10 @@ class HALProtocol(RepositoryProtocol):
             host = parsed_endpoint.netloc
             path = parsed_endpoint.path + 'hal'
 
-            conn = http_client.HTTPConnection(host)
+            if self.api_url.startswith('http://'):
+                conn = http_client.HTTPConnection(host)
+            else:
+                conn = http_client.HTTPSConnection(host)
             conn.putrequest('POST', path, True, True)
             zipContent = zipFile.getvalue()
             headers = {


### PR DESCRIPTION
This is a quick fix - the real solution would be to migrate to `requests`, but I have already tried a few years ago and failed, so that is why I am going down this route this time.

Closes #794