### PR TITLE
Patch Django-Haystack for memory consumption in queryset caching, #695

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ django-cas-ng
 django-countries
 django-crispy-forms
 django-geojson
-django-haystack
+# django-haystack, currently a custom fork because of #695
+https://github.com/dissemin/django-haystack/archive/queryset-cache-using-sparse_list-update.tar.gz
 django-js-reverse
 django-jsonview
 django-leaflet


### PR DESCRIPTION
Hopefully this should make Dissemin a lot more efficient. Our server running django and celery currently eats up almost all of our 16GB RAM…