### PR TITLE
Reduce number of queries when fetching upload page

### DIFF
--- a/deposit/views.py
+++ b/deposit/views.py
@@ -88,7 +88,7 @@ def start_view(request, pk):
     paper = get_object_or_404(
         Paper.objects.prefetch_related(
             'oairecord_set'
-        ), 
+        ),
         pk=pk
     )
     repositories = get_all_repositories_and_protocols(paper, request.user)

--- a/deposit/views.py
+++ b/deposit/views.py
@@ -85,7 +85,12 @@ def get_metadata_form(request):
 
 @user_passes_test(is_authenticated)
 def start_view(request, pk):
-    paper = get_object_or_404(Paper, pk=pk)
+    paper = get_object_or_404(
+        Paper.objects.prefetch_related(
+            'oairecord_set'
+        ), 
+        pk=pk
+    )
     repositories = get_all_repositories_and_protocols(paper, request.user)
     repositories_protocol = {repo.id :proto for repo, proto in repositories}
     


### PR DESCRIPTION
Reduce number of queries when fetching upload page (from 39 to 28)

Some queries remain doubled, because some code is executed twice. Probably some JS thing.