### PR TITLE
Enables non-interactive frontend for APT

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,11 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure("2") do |config|
+  # Load custom vbguest installer
+  if defined?(VagrantVbguest::Installers::Debian)
+      require_relative 'utility/vbg-installer'
+      config.vbguest.installer = Utility::DebianCustom
+  end
   # The most common configuration options are documented and commented below.
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -4,6 +4,9 @@ set -e
 # Show commands as they are executed
 set -x
 
+# Prevent interaction from apt with the user
+export DEBIAN_FRONTEND=noninteractive
+
 # We update the apt-get cache
 apt-get update
 # We update the system

--- a/utility/vbg-installer.rb
+++ b/utility/vbg-installer.rb
@@ -1,0 +1,36 @@
+module Utility
+
+    # Custom Debian installer for Vbguest
+    class DebianCustom < VagrantVbguest::Installers::Debian
+    
+        # Adds snapshot archive repo to sources
+        def install(opts=nil, &block)
+            
+            cmd = <<~SCRIPT
+                cat <<EOF > /etc/apt/sources.list.d/snapshot_archive.list
+                deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20190801T025637Z/ stretch main
+                deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20190801T025637Z/ stretch/updates main
+                EOF
+            SCRIPT
+
+            # Uncomment if running a Buster box
+            # cmd = <<~SCRIPT
+            #     cat <<EOF > /etc/apt/sources.list.d/snapshot_archive.list
+            #     deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20190812T140702Z/ buster main
+            #     deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20190812T140702Z/ buster/updates main
+            #     EOF
+            # SCRIPT
+
+            communicate.sudo(cmd, opts, &block)
+
+            super
+        end
+
+        def cleanup
+            # Uncomment to remove the snapshot archive repo from sources
+            # communicate.sudo('rm /etc/apt/sources.list.d/snapshot_archive.list')
+            
+            super
+        end
+    end
+end


### PR DESCRIPTION
Hey,

trying to use vagrant to install dissemin, I ran into one issue with grub breaking the workflow (basically, some ncurses menu rendered as text during the installation). This was due to APT not being configured to use a non-interactive installation method, which this pull requests enable.

Rémy