### PR TITLE
Accelerate html validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ services:
   - postgresql
   - redis
   - elasticsearch
+  - docker
 
 env:
   global:
@@ -33,6 +34,7 @@ env:
       # Zenodo Sandbox API key
     - secure: "KjRrTKrNyhv1xVl2UBtJ/qH0uFGItvxw7/pGFfPrcwxD5YAB5daePDaIGe/tlVy+lrQi0D9x1CA8MB2vm+Lf4jrfO+3ZHCkmb4ecbumPV7DxEbgFsralBx65PRRVUiDW1Oy0RyigxXNNdtNLvTVr1PYrZYD407HZnP6LrJP0ONM="
     - PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+    - USE_VNU_SERVER='YES'
 
 before_install:
   # Install latest tidy-html5
@@ -47,6 +49,7 @@ before_install:
   - export PIP_USE_MIRRORS=true
   - echo "from .travis import *" > dissemin/settings/__init__.py
   - cp dissemin/settings/secret_template.py dissemin/settings/secret.py
+  - docker run -d -it --rm -p 8888:8888 validator/validator:latest
 
 install:
   - pip install setuptools --upgrade

--- a/doc/sphinx/testing.rst
+++ b/doc/sphinx/testing.rst
@@ -14,9 +14,10 @@ for tests, and where Django's settings are located.
 Some tests rely on remote services. Some of them require API keys, they will fetch them
 from the following environment variables (or be skipped if these environment variables are
 not defined):
+
 * ``ROMEO_API_KEY`` 
-* ``ZENODO_SANDBOX_API_KEY`` required for tests of the Zenodo interface. This can be obtained
-  by creating an account on sandbox.zenodo.org and creating a "Personal Access Token" from there.
+* ``ZENODO_SANDBOX_API_KEY`` required for tests of the Zenodo interface.
+  This can be obtained by creating an account on sandbox.zenodo.org and creating a "Personal Access Token" from there.
 
 Fixtures
 --------
@@ -38,3 +39,24 @@ Mocking
 -------
 
 Currently we partially use mocking. If you write any new test, please use a proper mocking.
+
+
+Other
+-----
+
+HTML-Validation
+~~~~~~~~~~~~~~~
+
+Dissemin hast test for HTML validation. 
+Usually this validation is done for the English language, but we check for all available languages on Tuesday with Travis CI.
+For this we use the Nu Markup Checker (VNU).
+There are two possibilities to have the HTML checked:
+
+1. Using ``html5validator``-package
+2. Using server validation
+
+Per default we use the ``html5validator``, but it uses ``subprocess`` which tends to be slow for unknown reasons.
+(This really matters only if there are a lot of HTML validation tests, which is for standard development not the case.)
+To use this, you have to do nothing.
+
+To use the server validation, make sure you have a vnu-server running at ``localhost:8888`` and set the ``SHELL``-Variable ``USE_VNU_SERVER``.


### PR DESCRIPTION
By using vnu as server instead calling it via subprocess each time, we gain approximately 3 minutes per build.

In particular, calling `subprocess` often seems to make it slower. The reason is not known.

The main benefit it, that the Travis cron testing all languages should now finish in time and pass.

- [x] Offer option to use vnu server or subprocess
- [x] Use vnu server on travis
- [x] Documentation