### PR TITLE
Improvement of cached property publication

### DIFF
--- a/deposit/conftest.py
+++ b/deposit/conftest.py
@@ -7,8 +7,11 @@ from deposit.models import DDC
 from deposit.models import License
 from deposit.models import LicenseChooser
 from deposit.models import UserPreferences
+from papers.models import OaiRecord
 from papers.models import Paper
 from papers.models import Researcher
+from publishers.models import Journal
+from publishers.models import Publisher
 
 
 @pytest.fixture(params=[True, False])
@@ -69,6 +72,54 @@ def dissemin_xsd_1_0():
     testdir = os.path.dirname(os.path.abspath(__file__))
     dissemin_xsd = etree.parse(os.path.join(testdir, 'schema','dissemin_v1.0.xsd'))
     return etree.XMLSchema(dissemin_xsd)
+
+
+@pytest.fixture
+def dummy_journal(dummy_publisher):
+    """
+    Empty Journal with FK to Publisher
+    """
+    j = Journal.objects.create(
+        publisher=dummy_publisher,
+    )
+
+    return j
+
+
+@pytest.fixture
+def dummy_oairecord(dummy_paper, dummy_oaisource):
+    """
+    Empty OaiRecord with FK to empty_paper and empty OaiSource
+    """
+    o = OaiRecord.objects.create(
+        source=dummy_oaisource,
+        about=dummy_paper,
+        identifier='dummy',
+    )
+
+    return o
+
+
+@pytest.fixture
+def dummy_paper():
+    """
+    Just an empty paper
+    """
+    p =  Paper.objects.create(
+        pubdate='2019-10-08',
+    )
+
+    return p
+
+
+@pytest.fixture
+def dummy_publisher():
+    """
+    Empty Publisher
+    """
+    p = Publisher.objects.create()
+
+    return p
 
 
 @pytest.fixture

--- a/deposit/sword/protocol.py
+++ b/deposit/sword/protocol.py
@@ -9,7 +9,6 @@ from zipfile import ZipFile
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import MultipleObjectsReturned
-from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 
 from deposit.models import UserPreferences
@@ -250,24 +249,6 @@ class SWORDMETSProtocol(RepositoryProtocol):
                     data['email'] = r.email
 
         return data
-
-
-    @cached_property
-    def publication(self):
-        """
-        Sets publication / oairecord for the paper with highest prority.
-        """
-        # Fetch the first OaiRecord with highest OaiSource priority and journal as well as publisher
-        publication = self.paper.oairecord_set.filter(
-            journal_title__isnull=False,
-            publisher_name__isnull=False
-        ).order_by('priority').first()
-
-        # If this is not available, take the first one
-        if publication is None:
-           publication = self.paper.oairecord_set.order_by('priority').first()
-
-        return publication
 
 
     def submit_deposit(self, pdf, form):

--- a/deposit/tests/test_protocol.py
+++ b/deposit/tests/test_protocol.py
@@ -22,6 +22,7 @@ from datetime import date
 from io import BytesIO
 import unittest
 import django.test
+import copy
 import pytest
 import os
 
@@ -204,6 +205,90 @@ class MetaTestProtocol():
         Identifier should exist
         """
         assert len(self.protocol.protocol_identifier()) > 1
+
+
+    def test_publication_with_fk(self, db, dummy_oairecord, dummy_journal, dummy_publisher):
+        """
+        If journal and publisher are linked, this OaiRecord should be first. We add necessary data and then add another OaiRecord that should not be fetched.
+        """
+        self.protocol.paper = dummy_oairecord.about
+
+        dummy_oairecord.journal = dummy_journal
+        dummy_oairecord.publisher = dummy_publisher
+        dummy_oairecord.priority = 10
+        dummy_oairecord.save()
+
+        second_oairecord = copy.copy(dummy_oairecord)
+        second_oairecord.pk = None
+        second_oairecord.priority = 9
+        second_oairecord.identifier += '_2'
+        second_oairecord.save()
+
+        third_oairecord = copy.copy(dummy_oairecord)
+        third_oairecord.pk = None
+        third_oairecord.identifier += '_3'
+        third_oairecord.journal = None
+        third_oairecord.save()
+
+        assert self.protocol.publication.pk == dummy_oairecord.pk
+
+
+    def test_publication_with_names(self, db, dummy_oairecord):
+        """
+        If no journal or publisher are linked, the OaiRecord with journal_title and publisher_name should be first. We add necessary data and then add a second OaiRecord that should not be fetched.
+        """
+        self.protocol.paper = dummy_oairecord.about
+
+        dummy_oairecord.journal_title = 'Journal Title'
+        dummy_oairecord.publisher_name = 'Publisher Name'
+        dummy_oairecord.priority = 10
+        dummy_oairecord.save()
+
+        second_oairecord = copy.copy(dummy_oairecord)
+        second_oairecord.pk = None
+        second_oairecord.priority = 9
+        second_oairecord.identifier += '_2'
+        second_oairecord.save()
+
+        third_oairecord = copy.copy(dummy_oairecord)
+        third_oairecord.pk = None
+        third_oairecord.identifier += '_3'
+        third_oairecord.journal_title = ''
+        third_oairecord.save()
+
+        assert self.protocol.publication.pk == dummy_oairecord.pk
+
+
+    def test_publication_only_priority(self, db, dummy_oairecord):
+        """
+        If no OaiRecord has any information about journal or publisher, just give first
+        """
+        self.protocol.paper = dummy_oairecord.about
+
+        dummy_oairecord.priority = 10
+        dummy_oairecord.save()
+
+        second_oairecord = copy.copy(dummy_oairecord)
+        second_oairecord.pk = None
+        second_oairecord.priority = 9
+        second_oairecord.identifier += '_2'
+        second_oairecord.save()
+
+        assert self.protocol.publication.pk == dummy_oairecord.pk
+
+
+    def test_publication_no_result(self, dummy_paper):
+        """
+        If no OaiRecord can be found, we expect ``None``. Should in practice not happen.
+        """
+        self.protocol.paper = dummy_paper
+
+        assert self.protocol.publication == None
+
+
+
+
+
 
 
     @pytest.mark.parametrize('on_todolist', [True, False])


### PR DESCRIPTION
The cached property was bound to SWORDMETSProtocol, but should be usable by all other protocols, if they like to.

Additionally, tests were missing.