### PR TITLE
Deposit metadata improvements

### DIFF
--- a/deposit/protocol.py
+++ b/deposit/protocol.py
@@ -25,8 +25,6 @@ import traceback
 import logging
 
 from django.conf import settings
-from django.db.models import Q
-from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 from papers.baremodels import BareOaiRecord
 from deposit.forms import BaseMetadataForm
@@ -123,44 +121,6 @@ class RepositoryProtocol(object, metaclass = RepositoryProtocolMeta):
         Returns an identifier for the protocol.
         """
         return type(self).__name__
-
-    @cached_property
-    def publication(self):
-        """
-        Sets publication / oairecord for the paper with highest prority.
-        """
-        # Fetch the first OaiRecord with highest OaiSource priority and journal as well as publisher
-        publication = self.paper.oairecord_set.filter(
-                journal__isnull=False,
-                publisher__isnull=False
-            ).select_related(
-                'journal',
-                'publisher'
-            ).order_by(
-                '-priority'
-            ).first()
-
-        # If not available, fetch the first OaiRecord with highest OaiSource priority and journal_title as well as publisher_name
-        if publication is None:
-            publication = self.paper.oairecord_set.exclude(
-                    Q(journal_title='') | Q(publisher_name='')
-                ).select_related(
-                    'journal',
-                    'publisher'
-                ).order_by(
-                    '-priority'
-                ).first()
-
-        # If none is available, take the first one ordered by priority
-        if publication is None:
-           publication = self.paper.oairecord_set.select_related(
-                    'journal',
-                    'publisher'
-                ).order_by(
-                    '-priority'
-                ).first()
-
-        return publication
 
     def init_deposit(self, paper, user):
         """

--- a/deposit/tests/test_protocol.py
+++ b/deposit/tests/test_protocol.py
@@ -22,7 +22,6 @@ from datetime import date
 from io import BytesIO
 import unittest
 import django.test
-import copy
 import pytest
 import os
 
@@ -227,85 +226,6 @@ class MetaTestProtocol():
         Identifier should exist
         """
         assert len(self.protocol.protocol_identifier()) > 1
-
-
-    def test_publication_with_fk(self, db, dummy_oairecord, dummy_journal, dummy_publisher):
-        """
-        If journal and publisher are linked, this OaiRecord should be first. We add necessary data and then add another OaiRecord that should not be fetched.
-        """
-        self.protocol.paper = dummy_oairecord.about
-
-        dummy_oairecord.journal = dummy_journal
-        dummy_oairecord.publisher = dummy_publisher
-        dummy_oairecord.priority = 10
-        dummy_oairecord.save()
-
-        second_oairecord = copy.copy(dummy_oairecord)
-        second_oairecord.pk = None
-        second_oairecord.priority = 9
-        second_oairecord.identifier += '_2'
-        second_oairecord.save()
-
-        third_oairecord = copy.copy(dummy_oairecord)
-        third_oairecord.pk = None
-        third_oairecord.identifier += '_3'
-        third_oairecord.journal = None
-        third_oairecord.save()
-
-        assert self.protocol.publication.pk == dummy_oairecord.pk
-
-
-    def test_publication_with_names(self, db, dummy_oairecord):
-        """
-        If no journal or publisher are linked, the OaiRecord with journal_title and publisher_name should be first. We add necessary data and then add a second OaiRecord that should not be fetched.
-        """
-        self.protocol.paper = dummy_oairecord.about
-
-        dummy_oairecord.journal_title = 'Journal Title'
-        dummy_oairecord.publisher_name = 'Publisher Name'
-        dummy_oairecord.priority = 10
-        dummy_oairecord.save()
-
-        second_oairecord = copy.copy(dummy_oairecord)
-        second_oairecord.pk = None
-        second_oairecord.priority = 9
-        second_oairecord.identifier += '_2'
-        second_oairecord.save()
-
-        third_oairecord = copy.copy(dummy_oairecord)
-        third_oairecord.pk = None
-        third_oairecord.identifier += '_3'
-        third_oairecord.journal_title = ''
-        third_oairecord.save()
-
-        assert self.protocol.publication.pk == dummy_oairecord.pk
-
-
-    def test_publication_only_priority(self, db, dummy_oairecord):
-        """
-        If no OaiRecord has any information about journal or publisher, just give first
-        """
-        self.protocol.paper = dummy_oairecord.about
-
-        dummy_oairecord.priority = 10
-        dummy_oairecord.save()
-
-        second_oairecord = copy.copy(dummy_oairecord)
-        second_oairecord.pk = None
-        second_oairecord.priority = 9
-        second_oairecord.identifier += '_2'
-        second_oairecord.save()
-
-        assert self.protocol.publication.pk == dummy_oairecord.pk
-
-
-    def test_publication_no_result(self, dummy_paper):
-        """
-        If no OaiRecord can be found, we expect ``None``. Should in practice not happen.
-        """
-        self.protocol.paper = dummy_paper
-
-        assert self.protocol.publication == None
 
 
     @pytest.mark.parametrize('on_todolist', [True, False])

--- a/deposit/tests/test_utils.py
+++ b/deposit/tests/test_utils.py
@@ -1,0 +1,269 @@
+import pytest
+
+from deposit.utils import MetadataConverter
+
+from papers.models import OaiSource
+from papers.models import OaiRecord
+from publishers.models import Journal
+from publishers.models import Publisher
+
+@pytest.fixture
+def prefered_record(db, book_god_of_the_labyrinth):
+    """
+    The prefered record
+    """
+    prefered_source = OaiSource.objects.get(identifier='crossref')
+    prefered_publisher = Publisher.objects.create(
+        name='Prefered Publisher',
+        romeo_id='1'
+    )
+    prefered_journal = Journal.objects.create(
+        essn='0000-0001',
+        issn='0000-0010',
+        publisher=prefered_publisher,
+        title='Prefered Journal',
+
+    )
+    o = OaiRecord.objects.create(
+        about=book_god_of_the_labyrinth,
+        doi='10.1000/prefered',
+        identifier='test:prefered_record',
+        issue='prefered issue',
+        journal=prefered_journal,
+        journal_title='Prefered Journal on Record',
+        pages='S. 1-10',
+        publisher=prefered_publisher,
+        publisher_name='Prefered Publisher on Record',
+        source=prefered_source,
+        volume='prefered volume',
+    )
+    return o
+
+@pytest.fixture
+def alternative_record(db, book_god_of_the_labyrinth, dummy_oaisource):
+    """
+    A simple alternative OaiRecord
+    """
+    alternative_publisher = Publisher.objects.create(
+        name='Alternative Publisher',
+        romeo_id='2',
+    )
+    alternative_journal = Journal.objects.create(
+        essn='0000-0002',
+        issn='0000-0012',
+        publisher=alternative_publisher,
+        title='Alternative Journal',
+    )
+    o = OaiRecord.objects.create(
+        about=book_god_of_the_labyrinth,
+        doi='10.1000/alternative',
+        identifier='test:alternative_record',
+        issue='alternative issue',
+        journal=alternative_journal,
+        journal_title='Alternative Journal on Record',
+        pages='S. 11-20',
+        publisher=alternative_publisher,
+        publisher_name='Alternative Publisher on Record',
+        source=dummy_oaisource,
+        volume='alternative volume',
+
+    )
+    return o
+
+
+class TestMetadataConverter():
+
+    oairecord_keys = ['doi', 'essn', 'issn', 'issue', 'journal', 'pages', 'publisher', 'romeo_id', 'volume']
+    paper_keys = ['authors', 'doctype', 'pubdate', 'title']
+
+    @pytest.fixture(autouse=True)
+    def setup(self, book_god_of_the_labyrinth, prefered_record):
+        """
+        Sets the MetadataConverter ready to use and gives access to prefered and alternative record.
+        """
+        self.rp = prefered_record
+        self.mc = MetadataConverter(book_god_of_the_labyrinth)
+
+    def test_oai_metadata(self):
+        """
+        Check that every key exists and has a value
+        """
+        oai_metadata = self.mc.oai_metadata()
+        for key in self.oairecord_keys:
+            assert oai_metadata.get(key) is not None
+
+    def test_paper_metadata(self):
+        """
+        Check that every key exists and has a value
+        """
+        paper_metadata = self.mc.paper_metadata()
+        for key in self.paper_keys:
+            assert paper_metadata.get(key) is not None
+
+    def test_metadata(self):
+        """
+        Check that keys are there
+        """
+        metadata = self.mc.metadata()
+        for key in self.paper_keys + self.oairecord_keys:
+            assert metadata.get(key) is not None
+
+
+class TestMetadataConverterInit():
+    """
+    Groups tests about the class MetadataConverter
+    """
+    
+    def test_init_default(self, dummy_paper, dummy_oairecord):
+        """
+        If no prefered_records are set, OaiRecord list is just papers set of OaiRecords
+        """
+        mc = MetadataConverter(dummy_paper)
+        assert mc.paper == dummy_paper
+        assert len(mc.records) == 1
+        assert dummy_oairecord in mc.records
+
+    def test_init_prefered_records(self, dummy_paper, dummy_oairecord, prefered_record):
+        """
+        Prefered must be a list containing dummy_oairecord
+        """
+        mc = MetadataConverter(dummy_paper, [prefered_record])
+        assert mc.records[0] == prefered_record
+        assert mc.records[1] == dummy_oairecord
+
+
+class TestMetadataConverterOaiRecordDataCreation():
+    """
+    Groups tests about the class MetadataConverter that deal with creation of metadata from OaiRecords
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, dummy_paper, dummy_oairecord, dummy_publisher, dummy_journal):
+        """
+        Sets the MetadataConverter ready to use and gives access to prefered and alternative record.
+        """
+        self.record = dummy_oairecord
+        self.record.publisher = dummy_publisher
+        self.record.journal = dummy_journal
+        # We pass a prefered OaiRecord, so that we do not need to save
+        self.mc = MetadataConverter(dummy_paper, [dummy_oairecord])
+
+    @pytest.mark.parametrize('doi, expected', [('10.100/spam', '10.100/spam'), ('', None)])
+    def test_doi(self, doi, expected):
+        self.record.doi = doi
+        assert self.mc._get_doi() == expected
+
+    @pytest.mark.parametrize('essn, expected', [('0000-0000', '0000-0000'), ('', None)])
+    def test_essn(self, essn, expected):
+        self.record.journal.essn = essn
+        assert self.mc._get_essn() == expected
+
+    @pytest.mark.parametrize('issn, expected', [('0000-0000', '0000-0000'), ('', None)])
+    def test_issn(self, issn, expected):
+        self.record.journal.issn = issn
+        assert self.mc._get_issn() == expected
+
+    @pytest.mark.parametrize('issue, expected', [('issue 1', 'issue 1'), ('', None)])
+    def test_issue(self, issue, expected):
+        self.record.issue = issue
+        assert self.mc._get_issue() == expected
+
+    def test_journal(self):
+        title = 'journal title'
+        journal_title = 'another journal title'
+        self.record.journal.title = title
+        self.record.journal_title = journal_title
+        assert self.mc._get_journal() == title
+
+    def test_journal_no_journal(self):
+        self.record.journal = None
+        journal_title = 'journal title'
+        self.record.journal_title = journal_title
+        assert self.mc._get_journal() == journal_title
+
+    def test_journal_no_journal_title(self):
+        self.record.journal = None
+        assert self.mc._get_journal() is None
+
+    @pytest.mark.parametrize('pages, expected', [('1-10', '1-10'), ('', None)])
+    def test_get_pages(self, pages, expected):
+        self.record.pages = pages
+        assert self.mc._get_pages() == expected
+
+    def test_publisher(self):
+        name = 'publisher name'
+        publisher_name = 'another publisher name'
+        self.record.publisher.name = name
+        self.record.publisher_name = publisher_name
+        assert self.mc._get_publisher() == name
+
+    def test_publisher_no_publisher(self):
+        self.record.publisher = None
+        publisher_name = 'publisher name'
+        self.record.publisher_name = publisher_name
+        assert self.mc._get_publisher() == publisher_name
+
+    def test_publisher_no_publisher_name(self):
+        self.record.publisher = None
+        assert self.mc._get_publisher() is None
+
+    @pytest.mark.parametrize('romeo_id, expected', [('1', '1'), ('', None)])
+    def test_romeo_id(self, romeo_id, expected):
+        self.record.publisher.romeo_id = romeo_id
+        assert self.mc._get_romeo_id() == expected
+
+    @pytest.mark.parametrize('volume, expected', [('vol 10', 'vol 10'), ('', None)])
+    def test_get_volume(self, volume, expected):
+        self.record.volume = volume
+        assert self.mc._get_volume() == expected
+
+
+author_one =  [{
+    'name': {
+        'full': 'herbert quain',
+        'first': 'Herbert',
+        'last': 'Quain',
+    },
+    'orcid' : None
+}]
+
+author_two = [{
+    'name': {
+        'full': 'aristoteles',
+        'first': 'Aristoteles',
+        'last': 'Stageira'
+    },
+    'orcid': None,
+}]
+
+class TestMetadataConverterPaperDataCreation():
+    """
+    Groups all tests related to get data from the paper
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, dummy_paper):
+        """
+        Sets the MetadataConverter ready to use
+        """
+        self.paper = dummy_paper
+        self.mc = MetadataConverter(self.paper)
+
+        
+    @pytest.mark.parametrize('authors_list', [author_one, author_one + author_two])
+    def test_get_authors(self, authors_list):
+        """
+        Tests if authors are generated accordingly
+        """
+        self.paper.authors_list = authors_list
+
+        authors = self.mc._get_authors()
+
+        assert isinstance(authors, list)
+        assert len(authors) == len(authors_list)
+        for idx, author in enumerate(authors):
+            assert author['first'] == authors_list[idx]['name']['first']
+            assert author['last'] == authors_list[idx]['name']['last']
+            assert author['orcid'] == authors_list[idx]['orcid']
+
+

--- a/deposit/utils.py
+++ b/deposit/utils.py
@@ -1,0 +1,163 @@
+class MetadataConverter():
+    """
+    This class is able to convert our own metadata of a paper from the database into a relatively flat dictionary.
+
+    Additionally, since there is usually more than one OaiRecord for a paper, you can set a list of prefered OaiRecords to look for information first.
+
+    The OaiRecords are put into a list, where the prefered ones are first.
+    """
+
+    def __init__(self, paper, prefered_records=[]):
+        """
+        Initiates object with a paper and a list of prefered OaiRecords
+        :param paper: A paper object
+        :param prefered_records: Iterable of OaiRecords to investigate first for metadata
+        """
+        self.paper = paper
+        self.records = prefered_records + [r for r in paper.oairecord_set.all() if r not in prefered_records]
+
+    def metadata(self):
+        """
+        Returns all metadata from paper and its OaiRecords, using the prefered OaiRecord with priority
+        """
+        metadata = {
+            **self.paper_metadata(),
+            **self.oai_metadata(),
+        }
+        return metadata
+
+    def oai_metadata(self):
+        """
+        Gets only metadata from OaiRecord objects with prefered having priority
+        """
+        oai_metadata = {
+            'doi' : self._get_doi(),
+            'essn' : self._get_essn(),
+            'issn' : self._get_issn(),
+            'issue' : self._get_issue(),
+            'journal' : self._get_journal(),
+            'pages' : self._get_pages(),
+            'publisher' : self._get_publisher(),
+            'romeo_id' : self._get_romeo_id(),
+            'volume' : self._get_volume(),
+        }
+
+        return oai_metadata
+
+
+    def paper_metadata(self):
+        """
+        Gets only the metadata from the paper
+        """
+        paper_metadata = {
+            'authors' : self._get_authors(),
+            'doctype' : self.paper.doctype,
+            'pubdate' : self.paper.pubdate,
+            'title' : self.paper.title
+        }
+
+        return paper_metadata
+
+
+    def _get_authors(self):
+        """
+        Returns a list of authors, containing a dict with:
+        first
+        last
+        orcid
+        """
+        authors_list = [
+            {
+                'first' : author['name']['first'],
+                'last' : author['name']['last'],
+                'orcid' : author['orcid'],
+            }
+            for author in self.paper.authors_list
+        ]
+
+        return authors_list
+
+    def _get_doi(self):
+        """
+        Gets the DOI
+        :returns: DOI or None
+        """
+        for r in self.records:
+            if r.doi:
+                return r.doi
+
+    def _get_essn(self):
+        """
+        Gets the ESSN / EISSN
+        :returns: ESSN or None
+        """
+        for r in self.records:
+            if r.journal and r.journal.essn:
+                return r.journal.essn
+
+    def _get_issn(self):
+        """
+        Gets the ISSN
+        :returns: ISSN or None
+        """
+        for r in self.records:
+            if r.journal and r.journal.issn:
+                return r.journal.issn
+
+    def _get_issue(self):
+        """
+        Gets the issue
+        :returns: issue or None
+        """
+        for r in self.records:
+            if r.issue:
+                return r.issue
+
+    def _get_journal(self):
+        """
+        Gets the title from the journal
+        :returns: journal title or None
+        """
+        for r in self.records:
+            if r.journal:
+                return r.journal.title
+            if r.journal_title:
+                return r.journal_title
+
+    def _get_pages(self):
+        """
+        Gets the pages
+        :returns: pages or None
+        """
+        for r in self.records:
+            if r.pages:
+                return r.pages
+
+    def _get_publisher(self):
+        """
+        Gets the name from the publisher
+        :returns: publisher name or None
+        """
+        for r in self.records:
+            if r.publisher:
+                return r.publisher.name
+            if r.publisher_name:
+                return r.publisher_name
+
+    def _get_romeo_id(self):
+        """
+        Gets the romeo id
+        :returns: romeo id or None
+        """
+        for r in self.records:
+            if r.publisher and r.publisher.romeo_id:
+                return r.publisher.romeo_id
+
+    def _get_volume(self):
+        """
+        Gets the volume
+        :returns: volume or None
+        """
+        for r in self.records:
+            if r.volume:
+                return r.volume


### PR DESCRIPTION
This makes the creation of metadata way easier and clearer.

With `deposit.utils.MetadataConverter` you can get a flat dictionary with metadata from a paper and its OaiRecords.

You can give a preference, which OaiRecords to use first. If they do not have the information, the remaining will be used. This is per fields.