### PR TITLE
Run tests additionally on Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 
 sudo: false
 
@@ -14,8 +16,6 @@ addons:
        packages:
        - elasticsearch=2.4.5
        - openjdk-8-jre
-       - python-requests
-       - python-lxml
        - curl
        - libffi-dev
        - libssl-dev
@@ -54,7 +54,7 @@ before_install:
   - docker run -d -it --rm -p 8888:8888 validator/validator:latest
 
 install:
-  - pip install setuptools --upgrade
+  - pip install pip --upgrade
   - pip install psycopg2 --quiet
   - pip install -r requirements.txt --upgrade
   - pip install -r requirements-dev.txt --upgrade

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+attrs==17.4.0
 django-debug-toolbar
 django-extensions
 html5validator


### PR DESCRIPTION
Run test additionally on Python 3.7 and 3.8.

BTW: 3.5 drops out of support in September.

I wasn't able to switch to Bionic, since Elasticsearch 2.4.5 refused to run properly. It is possible to make ES 2.4.5 run on Bionic (this is the case on my dev virtual machine).