### PR TITLE
Enhance admin sites

### DIFF
--- a/deposit/admin.py
+++ b/deposit/admin.py
@@ -37,6 +37,13 @@ class LicenseChooserInline(admin.TabularInline):
     ordering = ('position', )
     extra = 1
 
+class DepositPreferencesAdmin(admin.ModelAdmin):
+    """
+    Meant to be subclassed by subclasses of DepositPreferences
+    """
+    raw_id_fields = ('user', )
+    search_fields = ('user__pk', 'user__username',)
+
 class DepositRecordAdmin(admin.ModelAdmin):
     list_display = ('identifier', 'paper', 'user')
     list_filter = ['repository']

--- a/deposit/hal/admin.py
+++ b/deposit/hal/admin.py
@@ -1,5 +1,10 @@
 
 from django.contrib import admin
-from .models import HALDepositPreferences
 
-admin.site.register(HALDepositPreferences)
+from .models import HALDepositPreferences
+from deposit.admin import DepositPreferencesAdmin
+
+class HALDepositPreferencesAdmin(DepositPreferencesAdmin):
+    pass
+
+admin.site.register(HALDepositPreferences, HALDepositPreferencesAdmin)

--- a/papers/admin.py
+++ b/papers/admin.py
@@ -15,8 +15,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+from solo.admin import SingletonModelAdmin
+from django_admin_relation_links import AdminChangeLinksMixin
 
 from django.contrib import admin
+from django.core.paginator import Paginator
+from django.db import connection, transaction, OperationalError
+from django.utils.functional import cached_property
+
 from papers.models import Department
 from papers.models import Institution
 from papers.models import Name
@@ -25,7 +31,30 @@ from papers.models import OaiSource
 from papers.models import Paper
 from papers.models import PaperWorld
 from papers.models import Researcher
-from solo.admin import SingletonModelAdmin
+
+
+class TimeLimitedPaginator(Paginator):
+    """
+    Paginator that enforced a timeout on the count operation.
+    When the timeout is reached a "fake" large value is returned instead,
+    Why does this hack exist? On every admin list view, Django issues a
+    COUNT on the full queryset. There is no simple workaround. On big tables,
+    this COUNT is extremely slow and makes things unbearable. This solution
+    is what we came up with.
+
+    Taken from: https://gist.github.com/hakib/5cbda96c8121299088115a94ec634903
+    """
+
+    @cached_property
+    def count(self):
+        # We set the timeout in a db transaction to prevent it from
+        # affecting other transactions.
+        with transaction.atomic(), connection.cursor() as cursor:
+            cursor.execute('SET LOCAL statement_timeout TO 400;')
+            try:
+                return super().count
+            except OperationalError:
+                return 9999999999
 
 
 class NameInline(admin.TabularInline):
@@ -36,22 +65,50 @@ class NameInline(admin.TabularInline):
 class OaiInline(admin.TabularInline):
     model = OaiRecord
     extra = 0
+    fields = ('identifier', 'source', 'splash_url', 'pdf_url', )
 
 
-class PaperAdmin(admin.ModelAdmin):
-    fields = ['title', 'pubdate', 'visible', 'doctype', 'oa_status']
+class DepartmentAdmin(admin.ModelAdmin):
+    raw_id_fields = ('institution', 'stats', )
+
+
+class OaiRecordAdmin(AdminChangeLinksMixin, admin.ModelAdmin):
+    paginator = TimeLimitedPaginator
+    search_fields = ('identifier', 'pk', )
+    raw_id_fields = ('about', 'journal', 'publisher', )
+    readonly_fields = ('last_update', )
+    show_full_result_count = False
+
+
+class PaperAdmin(AdminChangeLinksMixin, admin.ModelAdmin):
+    changelist_links = [
+        (
+            'oairecords',
+            {
+                'lookup_filter' : 'about',
+            },
+        ),
+    ]
     list_display = ('title', 'pubdate', 'visible', 'doctype', 'oa_status')
+    paginator = TimeLimitedPaginator
+    raw_id_fields = ('todolist', )
+    readonly_fields = ('last_modified', )
+    search_fields = ('pk', )
+    show_full_result_count = False
 
 
-class OaiRecordAdmin(admin.ModelAdmin):
-    raw_id_fields = ('about',)
+class PaperWorldAdmin(admin.ModelAdmin):
+    raw_id_fields = ('stats', )
 
 
 class ResearcherAdmin(admin.ModelAdmin):
-    raw_id_fields = ('name', 'stats',)
+    list_display = ('name', 'orcid', )
+    raw_id_fields = ('department', 'institution', 'name', 'user', 'stats', )
+    search_fields = ('user', 'orcid', )
+
 
 admin.site.register(Institution)
-admin.site.register(Department)
+admin.site.register(Department, DepartmentAdmin)
 admin.site.register(Researcher, ResearcherAdmin)
 admin.site.register(Name)
 admin.site.register(Paper, PaperAdmin)

--- a/papers/models.py
+++ b/papers/models.py
@@ -1376,6 +1376,9 @@ class OaiRecord(models.Model, BareOaiRecord):
     # Cached version of source.priority
     priority = models.IntegerField(default=1)
 
+    def __str__(self):
+        return self.identifier
+
     def update_priority(self):
         super(OaiRecord, self).update_priority()
         self.save(update_fields=['priority'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ bibtexparser>=1.1.0
 redis
 cryptography
 django>=2.2.0,<2.3.0
+django-admin-relation-links
 django-allauth
 django-bootstrap-pagination
 django-bulk-update

--- a/upload/admin.py
+++ b/upload/admin.py
@@ -25,6 +25,8 @@ from upload.models import UploadedPDF
 
 
 class UploadedPDFAdmin(admin.ModelAdmin):
-    list_display = ('file', 'user', 'timestamp')
+    list_display = ('pk', 'file', 'user', 'timestamp')
+    raw_id_fields = ('user', )
+    readonly_fields = ('timestamp', )
 
 admin.site.register(UploadedPDF, UploadedPDFAdmin)


### PR DESCRIPTION
Some of the admin sites were not usable, since we have to many model instances in our database. This is fixed by this PR, although we rarely need to inspect our instances in django admin.

The list of papers and oairecords has now a slightly misleading pagination (that does no errors). But this way we omit the 503 Gateway error, since otherwise a `select count(*) from` is performed, which takes too long.

Another new thing is that we can get from a paper object a list of its oairecords.