### PR TITLE
Hint that accordion elements on deposit page are collapsed

### DIFF
--- a/deposit/templates/deposit/start.html
+++ b/deposit/templates/deposit/start.html
@@ -37,7 +37,7 @@
         // Collapse Doctype card if choosen per GET
         {% if collapse_doctype %}
             $(function() {
-                $("#collapseDocType").collapse('hide')
+                $("#collapseDocType").collapse('hide');
             });
         {% endif %}
     </script>
@@ -102,7 +102,14 @@
                         <div class="card">
                             <a class="text-dark" data-toggle="collapse" href="#collapseDocType" aria-expanded="true" aria-controls="collapseDocType">
                                 <div class="card-header" id="headingDocType">
-                                    {% trans "Upload type:" %} <span id="choosenUploadType"></span>
+                                    <div class="row">
+                                        <div class="col">
+                                            {% trans "Upload type:" %} <span id="choosenUploadType"></span>
+                                        </div>
+                                        <div id="choosenUploadTypeUnfold" class="col-auto d-none">
+                                            <span class="text-primary small">{% trans "Change" %}</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </a>
                             <div class="collapse show" id="collapseDocType" aria-labelledby="headingDocType">
@@ -164,7 +171,14 @@
                         <div class="card">
                             <a class="text-dark" data-toggle="collapse" href="#collapseRepository" aria-expanded="true" aria-controls="collapseRepository">
                                 <div class="card-header" id="headingRepository">
-                                    {% trans "Repository:" %} <span id="choosenRepository"><strong>{{ selected_repository.name }}</strong></span>
+                                    <div class="row">
+                                        <div class="col">
+                                            {% trans "Repository:" %} <span id="choosenRepository"><strong>{{ selected_repository.name }}</strong></span>
+                                        </div>
+                                        <div id="choosenRepositoryUnfold" class="col-auto d-none">
+                                            <span class="text-primary small">{% trans "Change" %}</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </a>
                             <div class="collapse show" id="collapseRepository" aria-labelledby="headingRepository">
@@ -191,7 +205,14 @@
                         <div class="card">
                             <a class="text-dark" data-toggle="collapse" href="#collapseMetadata" aria-expanded="true" aria-controls="collapseMetadata">
                                 <div class="card-header" id="headingMetadata">
-                                    {% trans "Metadata:" %}
+                                    <div class="row">
+                                        <div class="col">
+                                            {% trans "Metadata:" %}
+                                        </div>
+                                        <div id="choosenMetadataUnfold" class="col-auto d-none">
+                                            <span class="text-primary small">{% trans "Change" %}</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </a>
                             <div id="errorMetadata"></div>

--- a/website/static/js/dissemin.js
+++ b/website/static/js/dissemin.js
@@ -716,6 +716,13 @@ $(function() {
     $("#collapseDocType").on('hidden.bs.collapse', function() {
         var selected = $("input[type='radio'][name='radioUploadType']:checked");
         $("#choosenUploadType").html($("#choosenUploadType-" + selected.val()).html())
+        $("#choosenUploadTypeUnfold").toggleClass("d-none");
+    });
+});
+
+$(function() {
+    $('#collapseDocType').on('shown.bs.collapse', function () {
+        $("#choosenUploadTypeUnfold").toggleClass("d-none");
     });
 });
 
@@ -750,6 +757,22 @@ $(function() {
     $("#collapseRepository").on("hidden.bs.collapse", function() {
         var selected = $("input[type='radio'][name='radioRepository']:checked");
         $("#choosenRepository").html($("#choosenRepository-" + selected.val()).html())
+        $("#choosenRepositoryUnfold").toggleClass("d-none");
+    });
+});
+
+$(function() {
+    $('#collapseRepository').on('shown.bs.collapse', function () {
+        $("#choosenRepositoryUnfold").toggleClass("d-none");
+    });
+});
+
+$(function() {
+    $('#collapseMetadata').on('shown.bs.collapse', function () {
+        $("#choosenMetadataUnfold").toggleClass("d-none");
+    });
+    $('#collapseMetadata').on('hidden.bs.collapse', function () {
+        $("#choosenMetadataUnfold").toggleClass("d-none");
     });
 });
 


### PR DESCRIPTION
UB Braunschweig mentioned, that one might think that chosen options on deposit page are not changable, since it might not be clear that one unfold an accordion element.

This PR simply adds the text "Change" to collapsed elements.

![Screenshot_2020-04-17 Ablegen Üçüncü Kranial Sinir Paralizisi ile Gelen Leptomeningeal Metastaz Olgusu - Dissemin](https://user-images.githubusercontent.com/29397922/79590319-224cbd80-80d7-11ea-8da8-1373f7053282.png)
