### PR TITLE
Hide Oairecords if they have a deposit that is not available

### DIFF
--- a/papers/templates/papers/paper_panel.html
+++ b/papers/templates/papers/paper_panel.html
@@ -19,21 +19,19 @@
 <h4 class="h-border">{% trans "Links" %}</h4>
 
 <ul class="list-unstyled">
-    {% for record in paper.sorted_oai_records %}
+    {% for record in paper.sorted_published_oairecords %}
         <li>
             {% if record.splash_url %}
                 <a href="{{ record.splash_url }}">
-            {% endif %}
-            {% if record.priority > 0 %}
-                {{ record.source_or_publisher }}
-            {% else %}
-                {% if record.splash_url %}
-                    [{{ record.splash_url |domain }}]
-                {% elif record.pdf_url %}
-                    [{{ record.pdf_url |domain }}]
+                {% if record.priority > 0 %}
+                    {{ record.source_or_publisher }}
+                {% else %}
+                    {% if record.splash_url %}
+                        [{{ record.splash_url |domain }}]
+                    {% elif record.pdf_url %}
+                        [{{ record.pdf_url |domain }}]
+                    {% endif %}
                 {% endif %}
-            {% endif %}
-            {% if record.splash_url %}
                 <small><span class="oi oi-external-link" aria-hidden="true"></span></small>
                 </a>{% if record.pdf_url %} | {% endif %}
             {% endif %}


### PR DESCRIPTION
Currently we even show links/sources, where we have status 'rejected'. A
lot of pending records point to 404 pages, which is after all very
misleading.
There's still a box for pending or embargoed records on the paper detail
page.