### PR TITLE
New short description of Dissemin for homepage and more

### DIFF
--- a/papers/templates/papers/index.html
+++ b/papers/templates/papers/index.html
@@ -24,8 +24,9 @@
 
     <p class="startButton">
     {% blocktrans trimmed %}
-    Dissemin detects papers behind pay-walls and invites their authors to
-    upload them in one click to an open repository.
+    With Dissemin, researchers can identify which works of theirs are behind
+    paywalls, and archive such papers in an open repository, in few clicks,
+    with an appropriate copyright statement.
     {% endblocktrans %}
     </p>
     


### PR DESCRIPTION
When reusing the description in certain places, like applications to some
orgs, we realised that the the sentence is ambiguous, as it might appear
that "detects... behind paywalls" might sound like Dissemin itself is
bypassing paywalls in some ways. It can be useful to use a more bland term
like "identify" or "list", and possibly stress it's generally about authors
finding their own work, and reusing it as allowed by copyright laws etc.

We might also want to tone down the promise of a "one click" process, as
there are quite a few more needed in general (especially if the abstract
is not available, and if one selects a CC license as everyone should),
not to mention the specific deposit flows of some universities.