### PR TITLE
Update Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,23 +7,21 @@
 # you're doing.
 Vagrant.configure("2") do |config|
   # Load custom vbguest installer
-  if defined?(VagrantVbguest::Installers::Debian)
-      require_relative 'utility/vbg-installer'
-      config.vbguest.installer = Utility::DebianCustom
-  end
   # The most common configuration options are documented and commented below.
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "debian/stretch64"
+  config.vm.box = "debian/contrib-buster64"
+  config.vm.box_version = "10.7"
+
 
   # We use VNU docker for some test (HTML-Validation)
   # Run it here
   config.vm.provision "docker" do |d|
     d.run "validator/validator:latest",
-      args: "-it -p 8888:8888"
+      args: "-it -p 8888:8888",
       daemonize: true
   end
 

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -9,8 +9,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 # We update the apt-get cache
 apt-get update
-# We update the system
-apt-get dist-upgrade -y
 
 # Install method HTTPS
 apt-get install -y apt-transport-https
@@ -18,6 +16,10 @@ apt-get install -y apt-transport-https
 # Add repository for ElasticSearch
 wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | apt-key add -
 echo "deb https://packages.elastic.co/elasticsearch/2.x/debian stable main" | tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list
+# Add repository for OpenJDK 8
+wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | sudo tee /etc/apt/sources.list.d/adoptopenjdk.list
+
 
 # We update the apt-get cache
 apt-get update
@@ -26,12 +28,18 @@ apt-get install -y build-essential curl screen libxml2-dev libxslt1-dev gettext 
         default-jre-headless libffi-dev \
         pwgen git
 apt-get install -y pdftk
-
+# Make imagemagick read pdf
+sudo sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read" pattern="PDF" \/>/' /etc/ImageMagick-6/policy.xml
 # We install Python
 apt-get install -y python3 python3-dev python3-venv
 # We install PostgreSQL now
 apt-get install -y postgresql postgresql-server-dev-all postgresql-client
 # We install ElasticSearch now
+# ES 2.4.x needs Java 8
+apt-get install -y adoptopenjdk-8-hotspot-jre
+# Then we must set this as default JRE
+sudo update-java-alternatives -s adoptopenjdk-8-hotspot-jre-amd64
+# Ready for ES
 apt-get install -y elasticsearch
 # We install moreutils
 apt-get install -y moreutils


### PR DESCRIPTION
Vagrant wasn't working, reasons where issues with the guest addition.

We also take the opportunity to update to buster from stretch.

Still, some tests are still failing.

* ElasticSearch needs quite a lot of memory, the VM has not very much of it, so increasing to 1GB should be fine, mabe we have to adjust JVM settings
* Tests related to PDF upload, maybe related to ImageMagick
* Test related with letter of declaration, probably related to pdftk
* CSS test fails, unkown reason
